### PR TITLE
Fix: Check for `$this->record` being set

### DIFF
--- a/src/Seo/Seo.php
+++ b/src/Seo/Seo.php
@@ -248,7 +248,7 @@ class Seo
             return $this->cleanUp($this->config['default']['image']);
         }
 
-        if (!empty($this->record->getExtras()['image'])) {
+        if ($this->record instanceof Content && !empty($this->record->getExtras()['image'])) {
             return $this->record->getExtras()['image']['url'];
         }
 


### PR DESCRIPTION
@Fredxd My apologies! The previous PR didn't cover this edge-case. We need to check for `$this->record` being set, or it might break on Listing pages. 🙈 