### PR TITLE
Better default initialisation of `seovalues`

### DIFF
--- a/templates/seo.html.twig
+++ b/templates/seo.html.twig
@@ -13,7 +13,7 @@
         robots: '',
         og: ''
     }|json_encode %}
-    {% if value is not json %}
+    {% if value is empty or value is not json %}
         {% set value = defaultValues %}
     {% endif %}
     {% set seovalues = value|json_decode %}

--- a/templates/seo.html.twig
+++ b/templates/seo.html.twig
@@ -13,7 +13,10 @@
         robots: '',
         og: ''
     }|json_encode %}
-    {% set seovalues = value|default(defaultValues)|json_decode %}
+    {% if value is not json %}
+        {% set value = defaultValues %}
+    {% endif %}
+    {% set seovalues = value|json_decode %}
 
     <div id="field-set-{{ name }}" class="form-group form-set is-normal">
         {% include '@bolt/_partials/fields/_label.html.twig' %}


### PR DESCRIPTION
Check if `value` is actually a JSON-like string. 

`|default` doesn't catch this edgecase, that occurs when the field is pre-filled when creating fixtures, for example.