### PR TITLE
Support listing_locale and contentTypeSlug overrides

### DIFF
--- a/src/Seo/Seo.php
+++ b/src/Seo/Seo.php
@@ -49,16 +49,21 @@ class Seo
 
     public function initialize(): void
     {
-        if (
-            ! $this->defaultsOverride &&
-            isset($this->config['override_default']) &&
-            isset($this->config['override_default'][$this->routeType])
-        ) {
-            $this->defaultsOverride = $this->config['override_default'][$this->routeType];
+        if (! $this->defaultsOverride && isset($this->config['override_default'])) {
+            $overrides = $this->config['override_default'];
+            if (isset($overrides[$this->routeType])) {
+                $this->defaultsOverride = $overrides[$this->routeType];
+            } elseif (in_array($this->routeType, ['listing', 'listing_locale'], true)) {
+                $slug = $this->request->get('contentTypeSlug');
+                if ($slug !== null && isset($overrides[$slug])) {
+                    $this->defaultsOverride = $overrides[$slug];
+                }
+            }
         }
 
         switch ($this->routeType) {
             case 'listing':
+            case 'listing_locale':
                 $contentTypeSlug = $this->request->get('contentTypeSlug');
                 $this->contentType = $this->boltConfig->getContentType($contentTypeSlug);
                 break;
@@ -82,6 +87,7 @@ class Seo
 
         switch ($this->routeType) {
             case 'listing':
+            case 'listing_locale':
                 return $this->cleanUp(
                     $this->contentType->get('name') . $this->postfixTitle()
                 );


### PR DESCRIPTION
## Summary

This PR updates appolodev/bolt-seo to treat listing_locale routes the same way it already treats listing routes when generating SEO data.

It adds support for the `listing_locale` route type when determining the ContentType used for listing pages.
Improves `override_default` resolution for listing routes by allowing overrides keyed by content type slug (`contentTypeSlug`), not only by route name.

### Why this is needed

On Bolt 6 sites, listing pages can be served under the `listing_locale` route (localized listing). In the current release, the extension only handles listing, so localized listings may not receive the correct title/meta defaults.

Also, many projects define listing SEO defaults per content type (e.g. override_default.blog) rather than a generic override_default.listing. Without this change, those per-content-type defaults don’t apply on listing routes, even though the route carries `contentTypeSlug`.

### Behavior change

For listing and listing_locale routes:

- If override_default[_route] exists, it is used (existing behavior).
- Otherwise, if override_default[contentTypeSlug] exists, it is used (new behavior).