### PR TITLE
fix: handle null in Seo::cleanUp when payoff/sitename is unset

### DIFF
--- a/src/Seo/Seo.php
+++ b/src/Seo/Seo.php
@@ -281,8 +281,12 @@ class Seo
         );
     }
 
-    private function cleanUp(string $string): string
+    private function cleanUp(?string $string): string
     {
+        if ($string === null) {
+            return '';
+        }
+
         $string = strip_tags($string);
         $string = str_replace(["\r", "\n"], '', $string);
         $string = preg_replace('/\s+/u', ' ', $string);


### PR DESCRIPTION
### Problem

When `general/payoff` (or `general/sitename`) is commented out / unset in a project's `config.yaml`, `Bolt\Configuration\Config::get()` returns `null`. This `null` is passed straight into `Seo::cleanUp()`, which declared its argument as a non-nullable `string`:

```php
private function cleanUp(string $string): string
```

The result is a hard `TypeError` during template rendering (HTTP 500):

```
Appolo\BoltSeo\Seo\Seo::cleanUp(): Argument #1 ($string) must be of type string, null given,
called in src/Seo/Seo.php on line 143
```

This breaks the front end on any site that doesn't define a payoff or sitename — e.g. the description fallback at `Seo::description()` (line 143) and the title fallback at `Seo::title()` (line 115).

### Fix

Make `cleanUp()` null-tolerant: accept `?string` and return an empty string for `null`.

```php
private function cleanUp(?string $string): string
{
    if ($string === null) {
        return '';
    }
    // ...
}
```

This guards every call site that sources its value from optional Bolt config (`general/payoff`, `general/sitename`) without changing behaviour for non-null input.

### How to reproduce

1. Comment out `payoff:` under `general` in `config/bolt/config.yaml`.
2. Load any page that renders the SEO meta tags.
3. Before: HTTP 500 `TypeError`. After: page renders, description simply falls back to empty.

### Scope

- Single file changed: `src/Seo/Seo.php`
- No behavioural change when payoff/sitename are set.
- No new dependencies.

