### PR TITLE
fix: guard override_default access for missing keys

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -53,6 +53,7 @@ meta_robots: "index, follow"
 #    homepage:
 #        title: 'Homepage Title'
 #        description: 'Description'
+#        keywords: ''
 #        robots: 'index, follow'
 #        ogtype: website
 #        canonical: ''
@@ -60,6 +61,7 @@ meta_robots: "index, follow"
 #    contact:
 #        title: 'Contact Title'
 #        description: 'Description'
+#        keywords: ''
 #        robots: 'index, nofollow'
 #        ogtype: website
 #        canonical: ''

--- a/src/Seo/Seo.php
+++ b/src/Seo/Seo.php
@@ -76,7 +76,7 @@ class Seo
     {
         $this->initialize();
 
-        if ($this->defaultsOverride && $this->defaultsOverride['title']) {
+        if (! empty($this->defaultsOverride['title'])) {
             return $this->cleanUp($this->defaultsOverride['title'] . $this->postfixTitle());
         }
 
@@ -119,7 +119,7 @@ class Seo
     {
         $this->initialize();
 
-        if ($this->defaultsOverride && $this->defaultsOverride['description']) {
+        if (! empty($this->defaultsOverride['description'])) {
             $description = $this->defaultsOverride['description'];
             return Html::trimText($description, $this->config['description_length']);
         }
@@ -150,7 +150,7 @@ class Seo
     {
         $this->initialize();
 
-        if ($this->defaultsOverride && $this->defaultsOverride['keywords']) {
+        if (! empty($this->defaultsOverride['keywords'])) {
             $keywords = $this->defaultsOverride['keywords'];
             return Html::trimText($keywords, $this->config['keywords_length']);
         }
@@ -173,7 +173,7 @@ class Seo
     {
         $this->initialize();
 
-        if ($this->defaultsOverride && $this->defaultsOverride['ogtype']) {
+        if (! empty($this->defaultsOverride['ogtype'])) {
             return $this->defaultsOverride['ogtype'];
         }
 
@@ -192,7 +192,7 @@ class Seo
     {
         $this->initialize();
 
-        if ($this->defaultsOverride && $this->defaultsOverride['robots']) {
+        if (! empty($this->defaultsOverride['robots'])) {
             return $this->defaultsOverride['robots'];
         }
 
@@ -210,7 +210,7 @@ class Seo
     {
         $this->initialize();
 
-        if ($this->defaultsOverride && $this->defaultsOverride['image']) {
+        if (! empty($this->defaultsOverride['image'])) {
             return $this->defaultsOverride['image'];
         }
 
@@ -236,7 +236,7 @@ class Seo
     {
         $this->initialize();
 
-        if ($this->defaultsOverride && $this->defaultsOverride['canonical']) {
+        if (! empty($this->defaultsOverride['canonical'])) {
             return $this->defaultsOverride['canonical'];
         }
 


### PR DESCRIPTION
## Fix: guard `override_default` access for missing keys

### Problem

When `override_default` is enabled for a route but the block omits one or more keys (e.g. `keywords`), the extension reads an array key that doesn't exist:

```php
if ($this->defaultsOverride && $this->defaultsOverride['keywords']) {
```

PHP raises an `Undefined array key "keywords"` warning, which in the dev environment is escalated to an HTTP 500 during template rendering:

```
An exception has been thrown during the rendering of a template
("Warning: Undefined array key "keywords"") in partials/_master.twig
```

The same unguarded access existed for every override key: `title`, `description`, `keywords`, `ogtype`, `robots`, `image`, and `canonical`. A partial override block — a perfectly valid config — could 500 the front end.

### Fix

Replace each `$this->defaultsOverride && $this->defaultsOverride['key']` check with `! empty($this->defaultsOverride['key'])`. This safely treats a missing key (or a null override) as "not overridden" and falls through to the normal SEO-field / default lookup.

```php
if (! empty($this->defaultsOverride['keywords'])) {
```

Also documents the optional `keywords` key in the `override_default` example in `config/config.yaml`.

### How to reproduce

1. In the extension config, enable `override_default` for a route without a `keywords` key:
   ```yaml
   override_default:
       homepage:
           title: 'Homepage Title'
           description: 'Description'
   ```
2. Load that route.
3. Before: HTTP 500 `Undefined array key "keywords"`. After: page renders, keywords fall back to the configured default.

### Scope

- `src/Seo/Seo.php` — 7 override lookups hardened.
- `config/config.yaml` — documents the optional `keywords` key.
- No behavioural change when all keys are present.