### PR TITLE
fix: prevent stored XSS in SEO snippet preview

### DIFF
--- a/assets/seo/seo.js
+++ b/assets/seo/seo.js
@@ -44,9 +44,9 @@ class SeoSnippet {
         if(this.seoData.description !== '') {
             defaultsData.description = this.seoData.description;
         }
-        this.targetElements.title.innerHTML = defaultsData.title;
-        this.targetElements.url.innerHTML = defaultsData.url.replace('REPLACE', defaultsData.slug);
-        this.targetElements.description.innerHTML = defaultsData.description;
+        this.targetElements.title.textContent = defaultsData.title;
+        this.targetElements.url.textContent = defaultsData.url.replace('REPLACE', defaultsData.slug);
+        this.targetElements.description.textContent = defaultsData.description;
     }
 
     initEvents() {
@@ -65,7 +65,7 @@ class SeoSnippet {
         if (this.inputs.slug) {
             this.inputs.slug.addEventListener('keyup', (e) => {
                 const defaultsData = Object.assign({}, this.defaultsData);
-                this.targetElements.url.innerHTML = defaultsData.url.replace('REPLACE', this.inputs.slug.value);
+                this.targetElements.url.textContent = defaultsData.url.replace('REPLACE', this.inputs.slug.value);
             });
         }
 
@@ -82,22 +82,46 @@ class SeoSnippet {
     }
 
     changeTarget(field) {
+        const seoFieldValue = this.seoFieldsInputs[field]
+            ? this.stripHtml(this.seoFieldsInputs[field].value)
+            : '';
+
         if (field === 'title' || field === 'description') {
             if (
                 this.inputs[field] &&
                 this.inputs[field].value.length > 0 &&
-                (!this.seoFieldsInputs[field] || this.seoFieldsInputs[field].value.length === 0)
+                seoFieldValue.length === 0
             ) {
-                this.targetElements[field].innerHTML = this.inputs[field].value;
-            } else if (this.seoFieldsInputs[field] && this.seoFieldsInputs[field].value.length > 0) {
-                this.targetElements[field].innerHTML = this.seoFieldsInputs[field].value;
+                this.targetElements[field].textContent = this.inputs[field].value;
+            } else if (seoFieldValue.length > 0) {
+                this.targetElements[field].textContent = seoFieldValue;
             } else {
-                this.targetElements[field].innerHTML = this.defaultsData[field];
+                this.targetElements[field].textContent = this.defaultsData[field];
             }
         }
 
-        this.seoData[field] = this.seoFieldsInputs[field].value;
-        this.seoField.value = JSON.stringify(this.seoData);
+        this.seoData[field] = seoFieldValue;
+        this.persist();
+    }
+
+    // Strips HTML from every field on save (not just the edited one), so legacy
+    // values stored before this sanitization existed are also cleaned and never
+    // re-persisted with HTML.
+    persist() {
+        const clean = {};
+        Object.keys(this.seoData).forEach((key) => {
+            clean[key] = typeof this.seoData[key] === 'string'
+                ? this.stripHtml(this.seoData[key])
+                : this.seoData[key];
+        });
+        this.seoField.value = JSON.stringify(clean);
+    }
+
+    // Removes all HTML tags from a value (and decodes entities) using an inert
+    // document, so stored SEO data stays plain text. DOMParser does not execute
+    // scripts or load resources, unlike assigning to a detached element's innerHTML.
+    stripHtml(value) {
+        return new DOMParser().parseFromString(value, 'text/html').body.textContent || '';
     }
 }
 


### PR DESCRIPTION
 ## Security fix: Stored XSS in SEO snippet preview
  
  ### The issue
  The admin SEO snippet preview rendered record-derived and stored SEO field values into the DOM using `innerHTML`. The SEO field is persisted raw, with no server-side sanitization on input, so an editor could save HTML such as `<img src=x onerror=...>` into a  record's SEO data.
  
  When any backend user later opened that record's edit screen, the stored payload was parsed by `innerHTML` and executed in their authenticated session — a **stored (persistent) XSS**. Because it ran in the admin context, it could be used to perform actions as  the victim user (e.g. other editors or administrators).
  
<img width="1267" height="715" alt="Screenshot 2026-06-12 at 8 45 32" src="https://github.com/user-attachments/assets/4c578e32-3961-4adc-898b-58cebf6b4404" />
  
  ### How it was fixed
  Defense in depth across two layers:

  1. **Preview rendering (the executing sink).** All preview writes now use `textContent` instead of `innerHTML`. The preview only ever displays plain text, so this is behavior-preserving and means stored markup is shown as literal text rather than parsed as  HTML — closing the execution path regardless of what is stored.

  2. **Sanitization on save.** SEO field values are now stripped of HTML before being persisted. A `stripHtml()` helper uses an inert `DOMParser` document — which neither executes scripts nor loads resources (unlike a detached element's `innerHTML`) — and  `persist()` runs it over the **entire** `seoData` object on every save. This cleans every field, including legacy HTML stored before this fix, so HTML is never (re-)persisted.

<img width="1236" height="572" alt="Screenshot 2026-06-12 at 8 36 23" src="https://github.com/user-attachments/assets/6beed837-42a2-4a62-a962-820bffaee7b7" />



  ### Notes
  - Client-side stripping is defense-in-depth, not the sole guarantee — it can be bypassed (direct API calls, devtools). The actual security guarantee is the `textContent` sink plus the existing server-side `strip_tags()` in `Seo::cleanUp()` and Twig auto-escaping of the meta template, which keep the public `<head>` output safe.
  - No functional/behavioral change for legitimate input: SEO fields are plain-text by design.