### PR TITLE
 Make the admin SEO snippet preview match the live `<title>`

### DIFF
--- a/assets/seo/seo.js
+++ b/assets/seo/seo.js
@@ -7,6 +7,10 @@ class SeoSnippet {
             description: this.container.dataset.baseDescription,
             slug: this.container.dataset.baseSlug,
         };
+        // The server resolves the title postfix (separator + postfix/sitename) exactly
+        // like the live <title>. Append it to the preview title so the snippet matches
+        // what the extension actually renders in the browser.
+        this.titlePostfix = this.container.dataset.baseTitlePostfix || '';
         this.targetElements = {
             url: document.querySelector('.seo_snippet span.url'),
             title: document.querySelector('.seo_snippet .title'),
@@ -44,7 +48,7 @@ class SeoSnippet {
         if(this.seoData.description !== '') {
             defaultsData.description = this.seoData.description;
         }
-        this.targetElements.title.textContent = defaultsData.title;
+        this.targetElements.title.textContent = defaultsData.title + this.titlePostfix;
         this.targetElements.url.textContent = defaultsData.url.replace('REPLACE', defaultsData.slug);
         this.targetElements.description.textContent = defaultsData.description;
     }
@@ -87,17 +91,23 @@ class SeoSnippet {
             : '';
 
         if (field === 'title' || field === 'description') {
+            let value;
             if (
                 this.inputs[field] &&
                 this.inputs[field].value.length > 0 &&
                 seoFieldValue.length === 0
             ) {
-                this.targetElements[field].textContent = this.inputs[field].value;
+                value = this.inputs[field].value;
             } else if (seoFieldValue.length > 0) {
-                this.targetElements[field].textContent = seoFieldValue;
+                value = seoFieldValue;
             } else {
-                this.targetElements[field].textContent = this.defaultsData[field];
+                value = this.defaultsData[field];
             }
+
+            // The postfix only applies to the title, never the description.
+            this.targetElements[field].textContent = field === 'title'
+                ? value + this.titlePostfix
+                : value;
         }
 
         this.seoData[field] = seoFieldValue;

--- a/src/Seo/Seo.php
+++ b/src/Seo/Seo.php
@@ -291,11 +291,22 @@ class Seo
         if ($this->config->get('title_postfix') === false) {
             return '';
         }
-        return sprintf(
-            ' %s %s',
-            $this->config->get('title_separator') !== '' ? $this->config->get('title_separator') : '|',
-            $this->config->get('title_postfix') !== '' ? $this->config->get('title_postfix') : $this->boltConfig->get('general/sitename')
-        );
+
+        $postfix = $this->config->get('title_postfix') !== ''
+            ? $this->config->get('title_postfix')
+            : $this->boltConfig->get('general/sitename');
+
+        // Nothing to append (no configured postfix and no sitename): omit the
+        // separator too — there is nothing to separate.
+        if ($postfix === null || $postfix === '') {
+            return '';
+        }
+
+        $separator = $this->config->get('title_separator') !== ''
+            ? $this->config->get('title_separator')
+            : '|';
+
+        return sprintf(' %s %s', $separator, $postfix);
     }
 
     /**

--- a/src/Twig/SeoExtension.php
+++ b/src/Twig/SeoExtension.php
@@ -78,8 +78,13 @@ class SeoExtension extends AbstractExtension
 
                 return $seoField ?: $description;
             case 'postfix':
+                // Mirror Seo::postfixTitle() exactly so the admin preview matches the
+                // live <title>: an empty separator falls back to `|` (not `-`), and an
+                // empty postfix falls back to the sitename.
                 if ($this->getExtensionConfig()->get('title_postfix') !== false) {
-                    $titleSeparator = $this->getExtensionConfig()->get('title_separator') ?: '-';
+                    $titleSeparator = $this->getExtensionConfig()->get('title_separator') !== ''
+                        ? $this->getExtensionConfig()->get('title_separator')
+                        : '|';
 
                     $titlePostfix = $this->getExtensionConfig()->get('title_postfix') !== ''
                         ? $this->getExtensionConfig()->get('title_postfix')

--- a/src/Twig/SeoExtension.php
+++ b/src/Twig/SeoExtension.php
@@ -80,16 +80,22 @@ class SeoExtension extends AbstractExtension
             case 'postfix':
                 // Mirror Seo::postfixTitle() exactly so the admin preview matches the
                 // live <title>: an empty separator falls back to `|` (not `-`), and an
-                // empty postfix falls back to the sitename.
+                // empty postfix falls back to the sitename. When the resolved postfix
+                // is empty (no postfix and no sitename) the separator is omitted too —
+                // there is nothing to separate.
                 if ($this->getExtensionConfig()->get('title_postfix') !== false) {
-                    $titleSeparator = $this->getExtensionConfig()->get('title_separator') !== ''
-                        ? $this->getExtensionConfig()->get('title_separator')
-                        : '|';
-
                     $titlePostfix = $this->getExtensionConfig()->get('title_postfix') !== ''
                         ? $this->getExtensionConfig()->get('title_postfix')
                         : $this->config->get('general/sitename')
                     ;
+
+                    if ($titlePostfix === null || $titlePostfix === '') {
+                        return '';
+                    }
+
+                    $titleSeparator = $this->getExtensionConfig()->get('title_separator') !== ''
+                        ? $this->getExtensionConfig()->get('title_separator')
+                        : '|';
 
                     return " {$titleSeparator} {$titlePostfix}";
                 }

--- a/tests/Seo/SeoTitleTest.php
+++ b/tests/Seo/SeoTitleTest.php
@@ -102,6 +102,18 @@ class SeoTitleTest extends SeoTestCase
         self::assertSame('Blog | Acme', $seo->title());
     }
 
+    public function testPostfixOmitsSeparatorWhenResolvedValueIsEmpty(): void
+    {
+        // No configured postfix and no sitename to fall back to: the resolved postfix
+        // is empty, so the separator must be omitted too (no dangling " | ").
+        $seo = $this->makeSeo('listing', [
+            'title_postfix' => '',
+            'title_separator' => '|',
+        ], contentTypeSlug: 'blog', contentType: $this->contentType('Blog'), siteName: null);
+
+        self::assertSame('Blog', $seo->title());
+    }
+
     public function testCleanUpStripsTagsAndCollapsesWhitespace(): void
     {
         $seo = $this->makeSeo('homepage', [

--- a/tests/Twig/SeoExtensionTest.php
+++ b/tests/Twig/SeoExtensionTest.php
@@ -182,6 +182,21 @@ class SeoExtensionTest extends TestCase
         self::assertSame('', $extension->seoFieldValue($this->contentWithFields([]), 'postfix'));
     }
 
+    public function testSeoFieldValuePostfixOmitsSeparatorWhenResolvedValueIsEmpty(): void
+    {
+        // No configured postfix and an empty sitename to fall back to: the resolved
+        // postfix is empty, so the separator is omitted too (matching Seo::postfixTitle).
+        $boltConfig = $this->createMock(Config::class);
+        $boltConfig->method('get')->willReturn('');
+
+        $extension = $this->makeExtension(
+            ['title_postfix' => '', 'title_separator' => '|'],
+            boltConfig: $boltConfig
+        );
+
+        self::assertSame('', $extension->seoFieldValue($this->contentWithFields([]), 'postfix'));
+    }
+
     public function testSeoFieldValueUnknownFieldReturnsEmptyString(): void
     {
         $extension = $this->makeExtension(['fields' => []]);

--- a/tests/Twig/SeoExtensionTest.php
+++ b/tests/Twig/SeoExtensionTest.php
@@ -166,13 +166,13 @@ class SeoExtensionTest extends TestCase
         $boltConfig = $this->createMock(Config::class);
         $boltConfig->method('get')->willReturn('Acme');
 
-        // Empty separator -> '-', empty postfix -> sitename.
+        // Empty separator -> '|' (matching Seo::postfixTitle), empty postfix -> sitename.
         $extension = $this->makeExtension(
             ['title_postfix' => '', 'title_separator' => ''],
             boltConfig: $boltConfig
         );
 
-        self::assertSame(' - Acme', $extension->seoFieldValue($this->contentWithFields([]), 'postfix'));
+        self::assertSame(' | Acme', $extension->seoFieldValue($this->contentWithFields([]), 'postfix'));
     }
 
     public function testSeoFieldValuePostfixDisabledReturnsEmptyString(): void


### PR DESCRIPTION
### Summary
The SEO snippet preview in the Bolt admin never displayed the title **postfix** (separator + postfix/sitename): the editor template rendered a `data-base-title-postfix` attribute, but `seo.js` ignored it, so the preview showed only the bare title. On top of that, the preview's postfix helper defaulted an empty separator to `-` while the live page uses `|`, so the two could disagree even where it was surfaced.

This PR makes the admin preview show **exactly** what the extension outputs in the browser, and fixes a small dangling-separator glitch in both.

### What changed
- **`seo.js`** now appends the resolved postfix to the snippet preview title (title only — never the description), updating live as you type.
- **`SeoExtension::seoFieldValue('postfix')`** now mirrors `Seo::postfixTitle()` exactly: empty separator → `|` (not `-`), empty postfix → sitename.
- **Dangling separator fix:** when the resolved postfix is empty (no `title_postfix` **and** no sitename), the separator is dropped too — no more trailing `Page Title | `. Applied to both the live `<title>` and the preview so they stay in sync.

### Behavior impact
- ✅  **No change for existing installs.** Any site with a sitename or a configured `title_postfix` renders the same `<title>` as before.
- The only live change is the degenerate case (no postfix *and* no sitename), which previously emitted a dangling ` | ` and now renders the title alone.
- Everything else is **admin-preview only**. The postfix is display-only and is never written into the saved SEO data.

### Screenshots

#### Default config (`title_separator: "|"`, `title_postfix: ''` → sitename)
The preview now shows the title followed by the separator and sitename, exactly as the page renders it.
<img width="1731" height="701" alt="default_values" src="https://github.com/user-attachments/assets/0292e16b-e123-4061-ac2a-7d6bb78f81c1" />



#### Custom override (configured `title_separator` / `title_postfix`)
A configured separator and postfix are reflected verbatim in the preview.
<img width="1605" height="687" alt="custom_overrides" src="https://github.com/user-attachments/assets/0a085ea0-28ea-42de-b40e-f11e2ee1913b" />


#### No separator / empty postfix
With nothing to append, the preview (and the live title) drop the separator entirely — no dangling ` | `.
<img width="1875" height="770" alt="no_separator" src="https://github.com/user-attachments/assets/ac54156d-52bd-4fb0-a18c-43dcfff50a54" />

### Tests
- Preview now matches live for the default-separator, configured-separator, disabled (`false`), and empty-resolved-postfix cases.
- Added coverage for the dangling-separator fix on **both** the live (`SeoTitleTest`) and preview (`SeoExtensionTest`) paths.
- `phpunit` (81 tests), `phpstan`, and `ecs` all pass.