### PR TITLE
Fix SEO for singleton pages, programmatic/paste input sync, and keywords whitespace

### DIFF
--- a/assets/seo/seo.js
+++ b/assets/seo/seo.js
@@ -50,30 +50,34 @@ class SeoSnippet {
     }
 
     initEvents() {
+        // Listen on `input` rather than `keyup` so the snippet preview and the
+        // persisted JSON stay in sync for every way a value can change — not just
+        // physical key presses, but also paste, browser autofill, and programmatic
+        // updates (e.g. automated form filling), all of which fire `input` but not
+        // `keyup`.
         if (this.inputs.title) {
-            this.inputs.title.addEventListener('keyup', (e) => {
+            this.inputs.title.addEventListener('input', (e) => {
                 this.changeTarget('title');
             });
         }
 
         if (this.inputs.description) {
-            this.inputs.description.addEventListener('keyup', (e) => {
+            this.inputs.description.addEventListener('input', (e) => {
                 this.changeTarget('description');
             });
         }
 
         if (this.inputs.slug) {
-            this.inputs.slug.addEventListener('keyup', (e) => {
+            this.inputs.slug.addEventListener('input', (e) => {
                 const defaultsData = Object.assign({}, this.defaultsData);
                 this.targetElements.url.textContent = defaultsData.url.replace('REPLACE', this.inputs.slug.value);
             });
         }
 
         Object.keys(this.seoFieldsInputs).forEach((key) => {
-            let eventName = 'keyup';
-            if (key === 'robots') {
-                eventName = 'change';
-            }
+            // `robots` is a <select>; the rest are text inputs/areas. `change`
+            // covers selects, `input` covers all text edits including paste/autofill.
+            const eventName = key === 'robots' ? 'change' : 'input';
 
             this.seoFieldsInputs[key].addEventListener(eventName, (e) => {
                 this.changeTarget(key);

--- a/src/Seo/Seo.php
+++ b/src/Seo/Seo.php
@@ -74,15 +74,29 @@ class Seo
             case 'listing_locale':
                 $contentTypeSlug = $this->request->get('contentTypeSlug');
                 $this->contentType = $this->boltConfig->getContentType($contentTypeSlug);
+                // A singleton content type is served on the listing route (its slug
+                // equals the content type slug), but it renders a single record and
+                // exposes a `record` global just like a detail route. Honour that
+                // record's own SEO field instead of only the content type defaults.
+                // Real collection listings expose `records` (plural), not `record`,
+                // so they are unaffected and keep using the content type name.
+                $this->loadRecordSeoFromTwig();
                 break;
             default:
-                if (! $this->record && isset($this->twig->getGlobals()['record'])) {
-                    $this->record = $this->twig->getGlobals()['record'];
-                    $field = $this->getSeoField($this->record);
-                    $this->seoData = $field && $field->__toString() ? json_decode($field->__toString(), true) : [];
-                }
+                $this->loadRecordSeoFromTwig();
                 break;
         }
+    }
+
+    private function loadRecordSeoFromTwig(): void
+    {
+        if ($this->record || ! isset($this->twig->getGlobals()['record'])) {
+            return;
+        }
+
+        $this->record = $this->twig->getGlobals()['record'];
+        $field = $this->getSeoField($this->record);
+        $this->seoData = $field && $field->__toString() ? json_decode($field->__toString(), true) : [];
     }
 
     public function title(): string
@@ -96,6 +110,20 @@ class Seo
         switch ($this->routeType) {
             case 'listing':
             case 'listing_locale':
+                // A singleton rendered on the listing route carries its own SEO
+                // field and title; prefer those before falling back to the content
+                // type name (which is all a real collection listing has).
+                if ($this->seoData && isset($this->seoData['title']) && $this->seoData['title'] !== '') {
+                    return $this->cleanUp($this->seoData['title'] . $this->postfixTitle());
+                }
+
+                if ($this->record) {
+                    $field = $this->getField($this->record, 'title');
+                    if ($field && $field->__toString() !== '') {
+                        return $this->cleanUp($field->__toString() . $this->postfixTitle());
+                    }
+                }
+
                 if ($this->contentType) {
                     return $this->cleanUp(
                         $this->contentType->get('name') . $this->postfixTitle()

--- a/templates/seo.html.twig
+++ b/templates/seo.html.twig
@@ -49,7 +49,7 @@
                 id="seofields-title"
                 maxlength="255"
                 type="text"
-                value="{{ seovalues.title|default('') }}"
+                value="{{ seovalues.title|default('')|trim }}"
             />
         </div>
 
@@ -72,7 +72,7 @@
                 class="form-control"
                 id="seofields-description"
                 style="height: 80px;"
-            >{{ seovalues.description|default('') }}</textarea>
+            >{{- seovalues.description|default('')|trim -}}</textarea>
         </div>
 
         <div id="field-{{ name }}-description_postfix" class="form--helper">
@@ -96,9 +96,7 @@
                         class="form-control"
                         id="seofields-keywords"
                         style="height: 80px;"
-                >
-                    {{ seovalues.keywords|default('') }}
-                </textarea>
+                >{{- seovalues.keywords|default('')|trim -}}</textarea>
             </div>
 
             <div id="field-{{ name }}-keywords_postfix" class="form--helper">
@@ -160,7 +158,7 @@
                     id="seofields-shortlink"
                     maxlength="255"
                     type="text"
-                    value="{{ seovalues.shortlink|default('') }}"
+                    value="{{ seovalues.shortlink|default('')|trim }}"
             />
         </div>
 
@@ -186,7 +184,7 @@
                     id="seofields-canonical"
                     maxlength="255"
                     type="text"
-                    value="{{ seovalues.canonical|default('') }}"
+                    value="{{ seovalues.canonical|default('')|trim }}"
             />
         </div>
 
@@ -242,7 +240,7 @@
                     id="seofields-og"
                     maxlength="255"
                     type="text"
-                    value="{{ seovalues.og|default('') }}"
+                    value="{{ seovalues.og|default('')|trim }}"
             />
         </div>
 

--- a/tests/Field/SeoFieldTest.php
+++ b/tests/Field/SeoFieldTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Appolo\BoltSeo\Tests\Field;
+
+use Appolo\BoltSeo\Field\SeoField;
+use Bolt\Configuration\Content\FieldType;
+use Bolt\Entity\Field;
+use Bolt\Entity\Field\Excerptable;
+use Bolt\Entity\Field\RawPersistable;
+use Bolt\Entity\FieldInterface;
+use PHPUnit\Framework\TestCase;
+use Twig\Markup;
+
+/**
+ * Smoke tests for the custom `seo` field type: it must declare the expected type
+ * and contracts, and render its stored JSON as Twig Markup (unescaped) rather
+ * than a plain string.
+ */
+class SeoFieldTest extends TestCase
+{
+    public function testTypeAndContracts(): void
+    {
+        $field = new SeoField();
+
+        self::assertSame('seo', SeoField::TYPE);
+        self::assertInstanceOf(Field::class, $field);
+        self::assertInstanceOf(FieldInterface::class, $field);
+        self::assertInstanceOf(Excerptable::class, $field);
+        self::assertInstanceOf(RawPersistable::class, $field);
+    }
+
+    public function testGetTwigValueReturnsMarkupWithStoredValue(): void
+    {
+        $field = $this->makeField('{"title":"Hello"}');
+
+        $value = $field->getTwigValue();
+
+        self::assertInstanceOf(Markup::class, $value);
+        self::assertSame('{"title":"Hello"}', (string) $value);
+    }
+
+    private function makeField(string $value): SeoField
+    {
+        $field = new SeoField();
+        $field->setDefinition('seo', new FieldType(['type' => 'seo']));
+        $field->setName('seo');
+        $field->setValue($value);
+
+        return $field;
+    }
+}

--- a/tests/Seo/SeoMetaTagsTest.php
+++ b/tests/Seo/SeoMetaTagsTest.php
@@ -59,6 +59,22 @@ class SeoMetaTagsTest extends SeoTestCase
         self::assertSame('Singleton seo description', $seo->description());
     }
 
+    public function testSingletonOnListingRouteFallsBackToRecordDescriptionField(): void
+    {
+        // A singleton on the listing route without a SEO description falls back to
+        // its own content field before the generic default.
+        $record = $this->record(['description' => 'About record description']);
+        $seo = $this->makeSeo(
+            'listing',
+            contentTypeSlug: 'about',
+            contentType: $this->contentType('About CT'),
+            record: $record,
+            payoff: 'Welcome',
+        );
+
+        self::assertSame('About record description', $seo->description());
+    }
+
     public function testDescriptionFallsBackToConfiguredDefault(): void
     {
         $seo = $this->makeSeo('record', [

--- a/tests/Seo/SeoMetaTagsTest.php
+++ b/tests/Seo/SeoMetaTagsTest.php
@@ -18,7 +18,11 @@ class SeoMetaTagsTest extends SeoTestCase
     public function testDescriptionUsesOverride(): void
     {
         $seo = $this->makeSeo('record', [
-            'override_default' => ['record' => ['description' => 'Override description']],
+            'override_default' => [
+                'record' => [
+                    'description' => 'Override description',
+                ],
+            ],
         ]);
 
         self::assertSame('Override description', $seo->description());
@@ -38,6 +42,21 @@ class SeoMetaTagsTest extends SeoTestCase
         $seo = $this->makeSeo('record', record: $record);
 
         self::assertSame('Record description', $seo->description());
+    }
+
+    public function testSingletonOnListingRouteUsesSeoFieldDescription(): void
+    {
+        // A singleton served on the listing route must expose its own SEO
+        // description, not fall back to the generic default.
+        $record = $this->recordWithSeoData(['description' => 'Singleton seo description']);
+        $seo = $this->makeSeo(
+            'listing',
+            contentTypeSlug: 'about',
+            contentType: $this->contentType('About CT'),
+            record: $record,
+        );
+
+        self::assertSame('Singleton seo description', $seo->description());
     }
 
     public function testDescriptionFallsBackToConfiguredDefault(): void

--- a/tests/Seo/SeoTitleTest.php
+++ b/tests/Seo/SeoTitleTest.php
@@ -73,6 +73,23 @@ class SeoTitleTest extends SeoTestCase
         self::assertSame('About Field Title', $seo->title());
     }
 
+    public function testSingletonOnListingLocaleRouteUsesSeoFieldTitle(): void
+    {
+        // The localized listing route (`listing_locale`) forwards a singleton the
+        // same way `listing` does, keeping the `_route` attribute. Its own SEO title
+        // must win over the content type name there too.
+        $record = $this->recordWithSeoData(['title' => 'About Us SEO'], ['title' => 'About']);
+
+        $seo = $this->makeSeo(
+            'listing_locale',
+            contentTypeSlug: 'about',
+            contentType: $this->contentType('About CT'),
+            record: $record,
+        );
+
+        self::assertSame('About Us SEO', $seo->title());
+    }
+
     public function testTaxonomyUsesTranslatedOverviewLabel(): void
     {
         $translator = $this->createMock(TranslatorInterface::class);

--- a/tests/Seo/SeoTitleTest.php
+++ b/tests/Seo/SeoTitleTest.php
@@ -16,7 +16,11 @@ class SeoTitleTest extends SeoTestCase
     public function testOverrideTitleWins(): void
     {
         $seo = $this->makeSeo('homepage', [
-            'override_default' => ['homepage' => ['title' => 'Override']],
+            'override_default' => [
+                'homepage' => [
+                    'title' => 'Override',
+                ],
+            ],
         ]);
 
         self::assertSame('Override', $seo->title());
@@ -34,6 +38,39 @@ class SeoTitleTest extends SeoTestCase
         $seo = $this->makeSeo('listing', contentTypeSlug: 'ghost', contentType: null);
 
         self::assertSame('My Site', $seo->title());
+    }
+
+    public function testSingletonOnListingRouteUsesSeoFieldTitle(): void
+    {
+        // A singleton content type is served on the listing route (its slug equals
+        // the content type slug) but renders a single record exposed as the `record`
+        // global. Its own SEO title must win over the content type name.
+        $record = $this->recordWithSeoData(['title' => 'About Us SEO'], ['title' => 'About']);
+
+        $seo = $this->makeSeo(
+            'listing',
+            contentTypeSlug: 'about',
+            contentType: $this->contentType('About CT'),
+            record: $record,
+        );
+
+        self::assertSame('About Us SEO', $seo->title());
+    }
+
+    public function testSingletonOnListingRouteFallsBackToRecordTitleField(): void
+    {
+        // Singleton record without a SEO title falls back to its title field before
+        // the content type name.
+        $record = $this->record(['title' => 'About Field Title']);
+
+        $seo = $this->makeSeo(
+            'listing',
+            contentTypeSlug: 'about',
+            contentType: $this->contentType('About CT'),
+            record: $record,
+        );
+
+        self::assertSame('About Field Title', $seo->title());
     }
 
     public function testTaxonomyUsesTranslatedOverviewLabel(): void


### PR DESCRIPTION
This MR bundles three independent SEO-extension bug fixes discovered while localizing content for a Bolt site. Each is small and self-contained; they're grouped because they were found together and all touch the SEO field flow.

## 1. Singleton content types ignored their own SEO field on the listing route

**Problem.** A singleton content type is served on the **`listing`** route, because its slug equals the content-type slug — yet it renders a single record (exposed as the `record` Twig global), much like a detail route. The `Seo` service only loaded the record's `seo` field in the default/detail branch, and `title()` returned the content-type *name* for listing routes before considering any record SEO. As a result, a singleton page (e.g. an "About" page) ignored its own SEO title/description/keywords entirely and fell back to the content-type name with no description.

**Fix.** Load the record's SEO field on listing routes too (when a singular `record` global is present), and prefer the record's SEO title — then its title field — over the content-type name. Real collection listings expose `records` (plural), not `record`, so they keep using the content-type name and are unaffected.

**Files.** `src/Seo/Seo.php`

**Tests.** Added regression tests for the singleton-on-listing title and description paths (`tests/Seo/SeoTitleTest.php`, `tests/Seo/SeoMetaTagsTest.php`).

## 2. SEO snippet only synced on `keyup`, losing paste/autofill/programmatic input

**Problem.** The snippet bound its title/description/keywords inputs (and the content title/slug/description preview inputs) to the **`keyup`** event, so the hidden JSON field was only serialized on a physical key press. Values set by **pasting**, **browser autofill**, or **programmatic/automated form filling** fire `input` but not `keyup` — so they appeared in the visible inputs but were never written to the persisted SEO field, and were silently lost on save.

**Fix.** Listen on **`input`** for the text inputs (keeping `change` for the `robots` `<select>`), which covers typing as well as paste, autofill and programmatic edits.

**Files.** `assets/seo/seo.js`

## 3. Stray leading/trailing whitespace in the Meta keywords textarea

**Problem.** The keywords `<textarea>` rendered its value on its own indented line, so the surrounding newline and indentation became part of the textarea's value — a leading and trailing run of whitespace shown in the editor and saved with the record. (The description textarea already placed its value flush against the tags; only keywords was affected.)

**Fix.** Render the keywords value flush against the tags using Twig whitespace-control, and apply `|trim` to every visible SEO value (title, description, keywords, shortlink, canonical, og) so no leading/trailing whitespace is ever shown or re-saved — even for values stored before this fix.

**Files.** `templates/seo.html.twig`

## Testing

- `vendor/bin/phpunit` — **82 passing**
- `vendor/bin/ecs check` — clean.
- Verified all three fixes end-to-end in a real Bolt admin + frontend:
  - Singleton SEO title/description/keywords now render per locale on the listing-served page; a real collection listing still uses the content-type name (no regression).
  - A plain programmatic `fill` of the SEO inputs now syncs to the hidden JSON without slow typing or manual event dispatch.
  - The keywords/description/title inputs render with no leading/trailing whitespace.