### PR TITLE
Enforce SEO field length limits and fix keywords translations

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -8,7 +8,7 @@ title_postfix: ''
 # The length used for the title and meta description. Note that increasing these values
 # will _not_ make them appear as longer snippets in Google.
 # Set a value (i.e. 255) for the `keywords_length`, to enable the meta keywords option.
-title_length: 70
+title_length: 60
 description_length: 158
 keywords_length: 0 #255
 

--- a/templates/seo.html.twig
+++ b/templates/seo.html.twig
@@ -47,7 +47,7 @@
                 name="{{ name }}[title]"
                 class="form-control"
                 id="seofields-title"
-                maxlength="255"
+                maxlength="{{ seoconfig.title_length|default(60) }}"
                 type="text"
                 value="{{ seovalues.title|default('') }}"
             />
@@ -55,7 +55,7 @@
 
         <div id="field-{{ name }}-title_postfix" class="form--helper">
             <p>{{ __("Will be used as the <tt>&lt;title&gt;</tt> and in search engines") }}.
-                {{ __("Limit the length to %number% characters", {'%number%': seoconfig.title_length|default(70)}) }}.</p>
+                {{ __("Limit the length to %number% characters", {'%number%': seoconfig.title_length|default(60)}) }}.</p>
         </div>
     </div>
 {% endblock %}
@@ -71,6 +71,7 @@
                 name="{{ name }}[description]"
                 class="form-control"
                 id="seofields-description"
+                maxlength="{{ seoconfig.description_length|default(158) }}"
                 style="height: 80px;"
             >{{ seovalues.description|default('') }}</textarea>
         </div>
@@ -95,6 +96,7 @@
                         name="{{ name }}[keywords]"
                         class="form-control"
                         id="seofields-keywords"
+                        maxlength="{{ keywords_length }}"
                         style="height: 80px;"
                 >
                     {{ seovalues.keywords|default('') }}

--- a/templates/seo.html.twig
+++ b/templates/seo.html.twig
@@ -106,7 +106,7 @@
             <div id="field-{{ name }}-keywords_postfix" class="form--helper">
                 <p>
                     {{ __('Will be used as the <tt>&lt;meta name="keywords"&gt;</tt>, and will show up in <em>some</em> search engines. Use comma separated tags only') }}.
-                    {{ __("Limit the length to %s characters", {'%s': keywords_length}) }}.
+                    {{ __("Limit the length to %number% characters", {'%number%': keywords_length}) }}.
                 </p>
             </div>
         </div>

--- a/translations/messages.cs.xlf
+++ b/translations/messages.cs.xlf
@@ -109,5 +109,17 @@
         <target><![CDATA[Použijte k nastavení <tt>&lt;meta name="og:type"&gt;</tt>]]></target>
       </segment>
     </unit>
+    <unit id="z9KeyMt" name="Meta keywords">
+      <segment>
+        <source>Meta keywords</source>
+        <target>Meta klíčová slova</target>
+      </segment>
+    </unit>
+    <unit id="z9KeyHl" name="Will be used as the &lt;tt&gt;&amp;lt;meta name=&quot;keywords&quot;&amp;gt;&lt;/tt&gt;, and will show up in &lt;em&gt;some&lt;/em&gt; search engines. Use comma separated tags only">
+      <segment>
+        <source>Will be used as the &lt;tt&gt;&amp;lt;meta name="keywords"&amp;gt;&lt;/tt&gt;, and will show up in &lt;em&gt;some&lt;/em&gt; search engines. Use comma separated tags only</source>
+        <target><![CDATA[Bude použito jako <tt>&lt;meta name="keywords"&gt;</tt> a zobrazí se v <em>některých</em> vyhledávačích. Používejte pouze značky oddělené čárkami]]></target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -109,5 +109,17 @@
         <target><![CDATA[Use this to set the <tt>&lt;meta name="og:type"&gt;</tt>]]></target>
       </segment>
     </unit>
+    <unit id="z9KeyMt" name="Meta keywords">
+      <segment>
+        <source>Meta keywords</source>
+        <target>Meta keywords</target>
+      </segment>
+    </unit>
+    <unit id="z9KeyHl" name="Will be used as the &lt;tt&gt;&amp;lt;meta name=&quot;keywords&quot;&amp;gt;&lt;/tt&gt;, and will show up in &lt;em&gt;some&lt;/em&gt; search engines. Use comma separated tags only">
+      <segment>
+        <source>Will be used as the &lt;tt&gt;&amp;lt;meta name="keywords"&amp;gt;&lt;/tt&gt;, and will show up in &lt;em&gt;some&lt;/em&gt; search engines. Use comma separated tags only</source>
+        <target><![CDATA[Will be used as the <tt>&lt;meta name="keywords"&gt;</tt>, and will show up in <em>some</em> search engines. Use comma separated tags only]]></target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -109,5 +109,17 @@
         <target><![CDATA[Utilisez ceci pour remplacer la balise <tt>&lt;meta name="og:type"&gt;</tt>]]></target>
       </segment>
     </unit>
+    <unit id="z9KeyMt" name="Meta keywords">
+      <segment>
+        <source>Meta keywords</source>
+        <target>Meta mots-clés</target>
+      </segment>
+    </unit>
+    <unit id="z9KeyHl" name="Will be used as the &lt;tt&gt;&amp;lt;meta name=&quot;keywords&quot;&amp;gt;&lt;/tt&gt;, and will show up in &lt;em&gt;some&lt;/em&gt; search engines. Use comma separated tags only">
+      <segment>
+        <source>Will be used as the &lt;tt&gt;&amp;lt;meta name="keywords"&amp;gt;&lt;/tt&gt;, and will show up in &lt;em&gt;some&lt;/em&gt; search engines. Use comma separated tags only</source>
+        <target><![CDATA[Sera utilisé comme <tt>&lt;meta name="keywords"&gt;</tt>, et apparaîtra dans <em>certains</em> moteurs de recherche. Utilisez uniquement des balises séparées par des virgules]]></target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/translations/messages.ru.xlf
+++ b/translations/messages.ru.xlf
@@ -109,5 +109,17 @@
         <target><![CDATA[Используйте это, чтобы задать <tt>&lt;meta name="og:type"&gt;</tt>]]></target>
       </segment>
     </unit>
+    <unit id="z9KeyMt" name="Meta keywords">
+      <segment>
+        <source>Meta keywords</source>
+        <target>Мета-ключевые слова</target>
+      </segment>
+    </unit>
+    <unit id="z9KeyHl" name="Will be used as the &lt;tt&gt;&amp;lt;meta name=&quot;keywords&quot;&amp;gt;&lt;/tt&gt;, and will show up in &lt;em&gt;some&lt;/em&gt; search engines. Use comma separated tags only">
+      <segment>
+        <source>Will be used as the &lt;tt&gt;&amp;lt;meta name="keywords"&amp;gt;&lt;/tt&gt;, and will show up in &lt;em&gt;some&lt;/em&gt; search engines. Use comma separated tags only</source>
+        <target><![CDATA[Будет использовано как <tt>&lt;meta name="keywords"&gt;</tt> и появится в <em>некоторых</em> поисковых системах. Используйте только теги, разделённые запятыми]]></target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/translations/messages.tr.xlf
+++ b/translations/messages.tr.xlf
@@ -109,5 +109,17 @@
         <target><![CDATA[<tt>&lt;meta name="og:type"&gt;</tt> belirlemek için kullanılır]]></target>
       </segment>
     </unit>
+    <unit id="z9KeyMt" name="Meta keywords">
+      <segment>
+        <source>Meta keywords</source>
+        <target>Meta anahtar kelimeler</target>
+      </segment>
+    </unit>
+    <unit id="z9KeyHl" name="Will be used as the &lt;tt&gt;&amp;lt;meta name=&quot;keywords&quot;&amp;gt;&lt;/tt&gt;, and will show up in &lt;em&gt;some&lt;/em&gt; search engines. Use comma separated tags only">
+      <segment>
+        <source>Will be used as the &lt;tt&gt;&amp;lt;meta name="keywords"&amp;gt;&lt;/tt&gt;, and will show up in &lt;em&gt;some&lt;/em&gt; search engines. Use comma separated tags only</source>
+        <target><![CDATA[<tt>&lt;meta name="keywords"&gt;</tt> olarak kullanılacak ve <em>bazı</em> arama motorlarında görünecektir. Yalnızca virgülle ayrılmış etiketler kullanın]]></target>
+      </segment>
+    </unit>
   </file>
 </xliff>


### PR DESCRIPTION
## Summary

Enforce the configured SEO field lengths in the admin UI and fix two i18n issues in the keywords field. Previously the length config was only applied when rendering the front-end meta tags — the editor inputs had a hardcoded `maxlength="255"` (title) or no limit at all (description, keywords), and the keywords label/helper text relied on translation strings the extension never shipped.

## Changes

### Enforce field lengths in the editor
- Drive the `maxlength` of the title, description, and keywords inputs from the configured `title_length` / `description_length` / `keywords_length` instead of a hardcoded `255` (title) or no limit (description, keywords). The editor now caps input to the same limits the front end trims to.
- Lower the recommended `title_length` from `70` to `60` to match the length Google actually displays in search results.

### Fix keywords length helper placeholder
- The keywords helper used the source string `"Limit the length to %s characters"`, for which the extension ships **no** translation. It therefore resolved against the host project's (or Bolt core's) catalog, where the placeholder had been baked into a literal number — so it showed a fixed value instead of `keywords_length`.
- Reuse the `"Limit the length to %number% characters"` string already used by the title and description helpers (which the extension translates in every locale), so the configured length is shown correctly.

### Ship missing keywords translations
- The `Meta keywords` label and its helper paragraph had no translation units in any locale, so they fell through to the host project's catalog (same class of issue as above).
- Add both units to all five locales (en / cs / fr / ru / tr) with the HTML markup and placeholders preserved. Every `__()` source string in `seo.html.twig` now resolves against the extension's own catalog.


## Testing

### When keywords are set to `0`, they are not rendered
- This is current behavior = remains unchanged

<img width="1133" height="886" alt="Screenshot 2026-06-17 at 14 03 32" src="https://github.com/user-attachments/assets/369d2c7d-6a08-4933-8e42-95576aeb892c" />


### Length values are properly visible in the admin UI and also enforced on HTML level
<img width="1542" height="747" alt="Screenshot 2026-06-17 at 14 01 44" src="https://github.com/user-attachments/assets/67aad850-ae13-4701-ac8b-dc925a46eb27" />




