### PR TITLE
feat(i18n): add multi-language support and fix SEO helper texts

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -51,6 +51,9 @@ jobs:
           - name: Check composer.json and composer.lock
             run: composer validate --strict --ansi
 
+          - name: Check XLIFF translation files
+            run: php bin/lint-xliff translations --ansi
+
           - name: PHPUnit
             run: vendor/bin/phpunit --colors=always
 

--- a/bin/lint-xliff
+++ b/bin/lint-xliff
@@ -1,0 +1,16 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Translation\Command\XliffLintCommand;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$command = new XliffLintCommand();
+
+$application = new Application('lint-xliff');
+$application->add($command);
+$application->setDefaultCommand($command->getName(), true);
+$application->run();

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         }
     },
     "scripts": {
-        "test": "phpunit"
+        "test": "phpunit",
+        "lint:xliff": "@php bin/lint-xliff translations"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/templates/seo.html.twig
+++ b/templates/seo.html.twig
@@ -166,8 +166,7 @@
 
         <div id="field-{{ name }}-shortlink_postfix" class="form--helper">
             <p>
-                {{ __("Use this to create an alias or shortlink to this record. Be sure to make it an absolute link.") }}
-                .
+                {{ __("Use this to create an alias or shortlink to this record. Be sure to make it an absolute link") }}.
             </p>
         </div>
     </div>

--- a/templates/seo.html.twig
+++ b/templates/seo.html.twig
@@ -248,7 +248,7 @@
 
         <div id="field-{{ name }}-og_postfix" class="form--helper">
             <p>
-                {{ __('Use this to set the <tt>&lt;meta name="og:type"&gt;</tt>') }}.
+                {{ __('Use this to set the <tt>&lt;meta property="og:type"&gt;</tt>') }}.
                 {{ __("Leave blank for the default") }}.
             </p>
         </div>

--- a/translations/messages.cs.xlf
+++ b/translations/messages.cs.xlf
@@ -37,6 +37,12 @@
         <target>Výchozí titulek</target>
       </segment>
     </unit>
+    <unit id="lONBiUz" name="default-title">
+      <segment>
+        <source>default-title</source>
+        <target>vychozi-titulek</target>
+      </segment>
+    </unit>
     <unit id="ORnQHm." name="Shortlink">
       <segment>
         <source>Shortlink</source>

--- a/translations/messages.cs.xlf
+++ b/translations/messages.cs.xlf
@@ -103,10 +103,10 @@
         <target><![CDATA[Použijte k nastavení <tt>&lt;meta name="robots"&gt;</tt>]]></target>
       </segment>
     </unit>
-    <unit id="HxdlzS6" name="Use this to set the &lt;tt&gt;&amp;lt;meta name=&quot;og:type&quot;&amp;gt;&lt;/tt&gt;">
+    <unit id="AXJdT4M" name="Use this to set the &lt;tt&gt;&amp;lt;meta property=&quot;og:type&quot;&amp;gt;&lt;/tt&gt;">
       <segment>
-        <source>Use this to set the &lt;tt&gt;&amp;lt;meta name="og:type"&amp;gt;&lt;/tt&gt;</source>
-        <target><![CDATA[Použijte k nastavení <tt>&lt;meta name="og:type"&gt;</tt>]]></target>
+        <source>Use this to set the &lt;tt&gt;&amp;lt;meta property="og:type"&amp;gt;&lt;/tt&gt;</source>
+        <target><![CDATA[Použijte k nastavení <tt>&lt;meta property="og:type"&gt;</tt>]]></target>
       </segment>
     </unit>
     <unit id="z9KeyMt" name="Meta keywords">

--- a/translations/messages.cs.xlf
+++ b/translations/messages.cs.xlf
@@ -61,10 +61,10 @@
         <target>Kanonický odkaz</target>
       </segment>
     </unit>
-    <unit id="pCpmxa8" name="Use this to create an alias or shortlink to this record. Be sure to make it an absolute link.">
+    <unit id="V.BIy_i" name="Use this to create an alias or shortlink to this record. Be sure to make it an absolute link">
       <segment>
-        <source>Use this to create an alias or shortlink to this record. Be sure to make it an absolute link.</source>
-        <target>Použijte k vytvoření aliasu nebo zkráceného odkazu na tento záznam. Ujistěte se, že se jedná o absolutní odkaz.</target>
+        <source>Use this to create an alias or shortlink to this record. Be sure to make it an absolute link</source>
+        <target>Použijte k vytvoření aliasu nebo zkráceného odkazu na tento záznam. Ujistěte se, že se jedná o absolutní odkaz</target>
       </segment>
     </unit>
     <unit id="FwLQ5cl" name="Use with caution, and only if you know what you're doing">

--- a/translations/messages.de.xlf
+++ b/translations/messages.de.xlf
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="de">
+  <file id="messages.de">
+    <unit id="4TCRcpL" name="SEO Title">
+      <segment>
+        <source>SEO Title</source>
+        <target>SEO-Titel</target>
+      </segment>
+    </unit>
+    <unit id="3p.vSSI" name="Will be used as the &lt;tt&gt;&amp;lt;title&amp;gt;&lt;/tt&gt; and in search engines">
+      <segment>
+        <source>Will be used as the &lt;tt&gt;&amp;lt;title&amp;gt;&lt;/tt&gt; and in search engines</source>
+        <target><![CDATA[Wird als <tt>&lt;title&gt;</tt> und in Suchmaschinen verwendet]]></target>
+      </segment>
+    </unit>
+    <unit id="HdE0ldo" name="Limit the length to %number% characters">
+      <segment>
+        <source>Limit the length to %number% characters</source>
+        <target>Beschränken Sie die Länge auf %number% Zeichen</target>
+      </segment>
+    </unit>
+    <unit id="JPCo9LS" name="Meta description">
+      <segment>
+        <source>Meta description</source>
+        <target>Meta-Beschreibung</target>
+      </segment>
+    </unit>
+    <unit id="2PqBQn1" name="Google snippet preview">
+      <segment>
+        <source>Google snippet preview</source>
+        <target>Google-Snippet-Vorschau</target>
+      </segment>
+    </unit>
+    <unit id="L.07lHq" name="Default title">
+      <segment>
+        <source>Default title</source>
+        <target>Standardtitel</target>
+      </segment>
+    </unit>
+    <unit id="lONBiUz" name="default-title">
+      <segment>
+        <source>default-title</source>
+        <target>standardtitel</target>
+      </segment>
+    </unit>
+    <unit id="ORnQHm." name="Shortlink">
+      <segment>
+        <source>Shortlink</source>
+        <target>Kurzlink</target>
+      </segment>
+    </unit>
+    <unit id="GgpqNso" name="alias">
+      <segment>
+        <source>alias</source>
+        <target>Alias</target>
+      </segment>
+    </unit>
+    <unit id="..3kd27" name="Canonical Link">
+      <segment>
+        <source>Canonical Link</source>
+        <target>Canonical-Link</target>
+      </segment>
+    </unit>
+    <unit id="V.BIy_i" name="Use this to create an alias or shortlink to this record. Be sure to make it an absolute link">
+      <segment>
+        <source>Use this to create an alias or shortlink to this record. Be sure to make it an absolute link</source>
+        <target>Verwenden Sie dies, um einen Alias oder Kurzlink zu diesem Datensatz zu erstellen. Achten Sie darauf, einen absoluten Link zu verwenden</target>
+      </segment>
+    </unit>
+    <unit id="FwLQ5cl" name="Use with caution, and only if you know what you're doing">
+      <segment>
+        <source>Use with caution, and only if you know what you're doing</source>
+        <target>Mit Vorsicht verwenden und nur, wenn Sie wissen, was Sie tun</target>
+      </segment>
+    </unit>
+    <unit id="n3BhrCh" name="Meta Robots Tag">
+      <segment>
+        <source>Meta Robots Tag</source>
+        <target>Meta-Robots-Tag</target>
+      </segment>
+    </unit>
+    <unit id="JEVKWPy" name="Open Graph Type">
+      <segment>
+        <source>Open Graph Type</source>
+        <target>Open-Graph-Typ</target>
+      </segment>
+    </unit>
+    <unit id="johNrI3" name="Leave blank for the default">
+      <segment>
+        <source>Leave blank for the default</source>
+        <target>Leer lassen für den Standardwert</target>
+      </segment>
+    </unit>
+    <unit id="CJ8orGK" name="Will be used as the &lt;tt&gt;&amp;lt;meta name=&quot;description&quot;&amp;gt;&lt;/tt&gt;, and will show up in search engines">
+      <segment>
+        <source>Will be used as the &lt;tt&gt;&amp;lt;meta name="description"&amp;gt;&lt;/tt&gt;, and will show up in search engines</source>
+        <target><![CDATA[Wird als <tt>&lt;meta name="description"&gt;</tt> verwendet und in Suchmaschinen angezeigt]]></target>
+      </segment>
+    </unit>
+    <unit id="0XJxYrt" name="Use this to override the &lt;tt&gt;&amp;lt;link rel=&quot;canonical&quot;&amp;gt;&lt;/tt&gt;">
+      <segment>
+        <source>Use this to override the &lt;tt&gt;&amp;lt;link rel="canonical"&amp;gt;&lt;/tt&gt;</source>
+        <target><![CDATA[Verwenden Sie dies, um den <tt>&lt;link rel="canonical"&gt;</tt> zu überschreiben]]></target>
+      </segment>
+    </unit>
+    <unit id="tGAPy_h" name="Use this to set the &lt;tt&gt;&amp;lt;meta name=&quot;robots&quot;&amp;gt;&lt;/tt&gt;">
+      <segment>
+        <source>Use this to set the &lt;tt&gt;&amp;lt;meta name="robots"&amp;gt;&lt;/tt&gt;</source>
+        <target><![CDATA[Verwenden Sie dies, um den <tt>&lt;meta name="robots"&gt;</tt> festzulegen]]></target>
+      </segment>
+    </unit>
+    <unit id="AXJdT4M" name="Use this to set the &lt;tt&gt;&amp;lt;meta property=&quot;og:type&quot;&amp;gt;&lt;/tt&gt;">
+      <segment>
+        <source>Use this to set the &lt;tt&gt;&amp;lt;meta property="og:type"&amp;gt;&lt;/tt&gt;</source>
+        <target><![CDATA[Verwenden Sie dies, um den <tt>&lt;meta property="og:type"&gt;</tt> festzulegen]]></target>
+      </segment>
+    </unit>
+    <unit id="z9KeyMt" name="Meta keywords">
+      <segment>
+        <source>Meta keywords</source>
+        <target>Meta-Keywords</target>
+      </segment>
+    </unit>
+    <unit id="z9KeyHl" name="Will be used as the &lt;tt&gt;&amp;lt;meta name=&quot;keywords&quot;&amp;gt;&lt;/tt&gt;, and will show up in &lt;em&gt;some&lt;/em&gt; search engines. Use comma separated tags only">
+      <segment>
+        <source>Will be used as the &lt;tt&gt;&amp;lt;meta name="keywords"&amp;gt;&lt;/tt&gt;, and will show up in &lt;em&gt;some&lt;/em&gt; search engines. Use comma separated tags only</source>
+        <target><![CDATA[Wird als <tt>&lt;meta name="keywords"&gt;</tt> verwendet und in <em>einigen</em> Suchmaschinen angezeigt. Verwenden Sie nur durch Kommas getrennte Tags]]></target>
+      </segment>
+    </unit>
+  </file>
+</xliff>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -103,10 +103,10 @@
         <target><![CDATA[Use this to set the <tt>&lt;meta name="robots"&gt;</tt>]]></target>
       </segment>
     </unit>
-    <unit id="HxdlzS6" name="Use this to set the &lt;tt&gt;&amp;lt;meta name=&quot;og:type&quot;&amp;gt;&lt;/tt&gt;">
+    <unit id="AXJdT4M" name="Use this to set the &lt;tt&gt;&amp;lt;meta property=&quot;og:type&quot;&amp;gt;&lt;/tt&gt;">
       <segment>
-        <source>Use this to set the &lt;tt&gt;&amp;lt;meta name="og:type"&amp;gt;&lt;/tt&gt;</source>
-        <target><![CDATA[Use this to set the <tt>&lt;meta name="og:type"&gt;</tt>]]></target>
+        <source>Use this to set the &lt;tt&gt;&amp;lt;meta property="og:type"&amp;gt;&lt;/tt&gt;</source>
+        <target><![CDATA[Use this to set the <tt>&lt;meta property="og:type"&gt;</tt>]]></target>
       </segment>
     </unit>
     <unit id="z9KeyMt" name="Meta keywords">

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -37,6 +37,12 @@
         <target>Default title</target>
       </segment>
     </unit>
+    <unit id="lONBiUz" name="default-title">
+      <segment>
+        <source>default-title</source>
+        <target>default-title</target>
+      </segment>
+    </unit>
     <unit id="ORnQHm." name="Shortlink">
       <segment>
         <source>Shortlink</source>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -61,10 +61,10 @@
         <target>Canonical Link</target>
       </segment>
     </unit>
-    <unit id="pCpmxa8" name="Use this to create an alias or shortlink to this record. Be sure to make it an absolute link.">
+    <unit id="V.BIy_i" name="Use this to create an alias or shortlink to this record. Be sure to make it an absolute link">
       <segment>
-        <source>Use this to create an alias or shortlink to this record. Be sure to make it an absolute link.</source>
-        <target>Use this to create an alias or shortlink to this record. Be sure to make it an absolute link.</target>
+        <source>Use this to create an alias or shortlink to this record. Be sure to make it an absolute link</source>
+        <target>Use this to create an alias or shortlink to this record. Be sure to make it an absolute link</target>
       </segment>
     </unit>
     <unit id="FwLQ5cl" name="Use with caution, and only if you know what you're doing">

--- a/translations/messages.es.xlf
+++ b/translations/messages.es.xlf
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="es">
+  <file id="messages.es">
+    <unit id="4TCRcpL" name="SEO Title">
+      <segment>
+        <source>SEO Title</source>
+        <target>Título SEO</target>
+      </segment>
+    </unit>
+    <unit id="3p.vSSI" name="Will be used as the &lt;tt&gt;&amp;lt;title&amp;gt;&lt;/tt&gt; and in search engines">
+      <segment>
+        <source>Will be used as the &lt;tt&gt;&amp;lt;title&amp;gt;&lt;/tt&gt; and in search engines</source>
+        <target><![CDATA[Se usará como <tt>&lt;title&gt;</tt> y en los motores de búsqueda]]></target>
+      </segment>
+    </unit>
+    <unit id="HdE0ldo" name="Limit the length to %number% characters">
+      <segment>
+        <source>Limit the length to %number% characters</source>
+        <target>Limite la longitud a %number% caracteres</target>
+      </segment>
+    </unit>
+    <unit id="JPCo9LS" name="Meta description">
+      <segment>
+        <source>Meta description</source>
+        <target>Metadescripción</target>
+      </segment>
+    </unit>
+    <unit id="2PqBQn1" name="Google snippet preview">
+      <segment>
+        <source>Google snippet preview</source>
+        <target>Vista previa del fragmento de Google</target>
+      </segment>
+    </unit>
+    <unit id="L.07lHq" name="Default title">
+      <segment>
+        <source>Default title</source>
+        <target>Título predeterminado</target>
+      </segment>
+    </unit>
+    <unit id="lONBiUz" name="default-title">
+      <segment>
+        <source>default-title</source>
+        <target>titulo-predeterminado</target>
+      </segment>
+    </unit>
+    <unit id="ORnQHm." name="Shortlink">
+      <segment>
+        <source>Shortlink</source>
+        <target>Enlace corto</target>
+      </segment>
+    </unit>
+    <unit id="GgpqNso" name="alias">
+      <segment>
+        <source>alias</source>
+        <target>alias</target>
+      </segment>
+    </unit>
+    <unit id="..3kd27" name="Canonical Link">
+      <segment>
+        <source>Canonical Link</source>
+        <target>Enlace canónico</target>
+      </segment>
+    </unit>
+    <unit id="V.BIy_i" name="Use this to create an alias or shortlink to this record. Be sure to make it an absolute link">
+      <segment>
+        <source>Use this to create an alias or shortlink to this record. Be sure to make it an absolute link</source>
+        <target>Úselo para crear un alias o enlace corto a este registro. Asegúrese de que sea un enlace absoluto</target>
+      </segment>
+    </unit>
+    <unit id="FwLQ5cl" name="Use with caution, and only if you know what you're doing">
+      <segment>
+        <source>Use with caution, and only if you know what you're doing</source>
+        <target>Use con precaución y solo si sabe lo que está haciendo</target>
+      </segment>
+    </unit>
+    <unit id="n3BhrCh" name="Meta Robots Tag">
+      <segment>
+        <source>Meta Robots Tag</source>
+        <target>Etiqueta Meta Robots</target>
+      </segment>
+    </unit>
+    <unit id="JEVKWPy" name="Open Graph Type">
+      <segment>
+        <source>Open Graph Type</source>
+        <target>Tipo de Open Graph</target>
+      </segment>
+    </unit>
+    <unit id="johNrI3" name="Leave blank for the default">
+      <segment>
+        <source>Leave blank for the default</source>
+        <target>Déjelo en blanco para el valor predeterminado</target>
+      </segment>
+    </unit>
+    <unit id="CJ8orGK" name="Will be used as the &lt;tt&gt;&amp;lt;meta name=&quot;description&quot;&amp;gt;&lt;/tt&gt;, and will show up in search engines">
+      <segment>
+        <source>Will be used as the &lt;tt&gt;&amp;lt;meta name="description"&amp;gt;&lt;/tt&gt;, and will show up in search engines</source>
+        <target><![CDATA[Se usará como <tt>&lt;meta name="description"&gt;</tt> y aparecerá en los motores de búsqueda]]></target>
+      </segment>
+    </unit>
+    <unit id="0XJxYrt" name="Use this to override the &lt;tt&gt;&amp;lt;link rel=&quot;canonical&quot;&amp;gt;&lt;/tt&gt;">
+      <segment>
+        <source>Use this to override the &lt;tt&gt;&amp;lt;link rel="canonical"&amp;gt;&lt;/tt&gt;</source>
+        <target><![CDATA[Úselo para sobrescribir el <tt>&lt;link rel="canonical"&gt;</tt>]]></target>
+      </segment>
+    </unit>
+    <unit id="tGAPy_h" name="Use this to set the &lt;tt&gt;&amp;lt;meta name=&quot;robots&quot;&amp;gt;&lt;/tt&gt;">
+      <segment>
+        <source>Use this to set the &lt;tt&gt;&amp;lt;meta name="robots"&amp;gt;&lt;/tt&gt;</source>
+        <target><![CDATA[Úselo para establecer el <tt>&lt;meta name="robots"&gt;</tt>]]></target>
+      </segment>
+    </unit>
+    <unit id="AXJdT4M" name="Use this to set the &lt;tt&gt;&amp;lt;meta property=&quot;og:type&quot;&amp;gt;&lt;/tt&gt;">
+      <segment>
+        <source>Use this to set the &lt;tt&gt;&amp;lt;meta property="og:type"&amp;gt;&lt;/tt&gt;</source>
+        <target><![CDATA[Úselo para establecer el <tt>&lt;meta property="og:type"&gt;</tt>]]></target>
+      </segment>
+    </unit>
+    <unit id="z9KeyMt" name="Meta keywords">
+      <segment>
+        <source>Meta keywords</source>
+        <target>Meta palabras clave</target>
+      </segment>
+    </unit>
+    <unit id="z9KeyHl" name="Will be used as the &lt;tt&gt;&amp;lt;meta name=&quot;keywords&quot;&amp;gt;&lt;/tt&gt;, and will show up in &lt;em&gt;some&lt;/em&gt; search engines. Use comma separated tags only">
+      <segment>
+        <source>Will be used as the &lt;tt&gt;&amp;lt;meta name="keywords"&amp;gt;&lt;/tt&gt;, and will show up in &lt;em&gt;some&lt;/em&gt; search engines. Use comma separated tags only</source>
+        <target><![CDATA[Se usará como <tt>&lt;meta name="keywords"&gt;</tt> y aparecerá en <em>algunos</em> motores de búsqueda. Use solo etiquetas separadas por comas]]></target>
+      </segment>
+    </unit>
+  </file>
+</xliff>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -37,6 +37,12 @@
         <target>Titre par défaut</target>
       </segment>
     </unit>
+    <unit id="lONBiUz" name="default-title">
+      <segment>
+        <source>default-title</source>
+        <target>titre-par-defaut</target>
+      </segment>
+    </unit>
     <unit id="ORnQHm." name="Shortlink">
       <segment>
         <source>Shortlink</source>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -16,7 +16,7 @@
     <unit id="HdE0ldo" name="Limit the length to %number% characters">
       <segment>
         <source>Limit the length to %number% characters</source>
-        <target>Longueur recommandée à %number% caractères</target>
+        <target>Limitez la longueur à %number% caractères</target>
       </segment>
     </unit>
     <unit id="JPCo9LS" name="Meta description">
@@ -106,13 +106,13 @@
     <unit id="tGAPy_h" name="Use this to set the &lt;tt&gt;&amp;lt;meta name=&quot;robots&quot;&amp;gt;&lt;/tt&gt;">
       <segment>
         <source>Use this to set the &lt;tt&gt;&amp;lt;meta name="robots"&amp;gt;&lt;/tt&gt;</source>
-        <target><![CDATA[Utilisez-le pour remplacer la balise <tt>&lt;meta name="robots"&gt;</tt>]]></target>
+        <target><![CDATA[Utilisez-le pour définir la balise <tt>&lt;meta name="robots"&gt;</tt>]]></target>
       </segment>
     </unit>
     <unit id="AXJdT4M" name="Use this to set the &lt;tt&gt;&amp;lt;meta property=&quot;og:type&quot;&amp;gt;&lt;/tt&gt;">
       <segment>
         <source>Use this to set the &lt;tt&gt;&amp;lt;meta property="og:type"&amp;gt;&lt;/tt&gt;</source>
-        <target><![CDATA[Utilisez ceci pour remplacer la balise <tt>&lt;meta property="og:type"&gt;</tt>]]></target>
+        <target><![CDATA[Utilisez-le pour définir la balise <tt>&lt;meta property="og:type"&gt;</tt>]]></target>
       </segment>
     </unit>
     <unit id="z9KeyMt" name="Meta keywords">

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -61,10 +61,10 @@
         <target>Lien canonique</target>
       </segment>
     </unit>
-    <unit id="pCpmxa8" name="Use this to create an alias or shortlink to this record. Be sure to make it an absolute link.">
+    <unit id="V.BIy_i" name="Use this to create an alias or shortlink to this record. Be sure to make it an absolute link">
       <segment>
-        <source>Use this to create an alias or shortlink to this record. Be sure to make it an absolute link.</source>
-        <target>Utilisez-le pour créer un alias ou un lien court vers cet enregistrement. Assurez-vous qu'il soit un lien absolu.</target>
+        <source>Use this to create an alias or shortlink to this record. Be sure to make it an absolute link</source>
+        <target>Utilisez-le pour créer un alias ou un lien court vers cet enregistrement. Assurez-vous qu'il soit un lien absolu</target>
       </segment>
     </unit>
     <unit id="FwLQ5cl" name="Use with caution, and only if you know what you're doing">

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -22,7 +22,7 @@
     <unit id="JPCo9LS" name="Meta description">
       <segment>
         <source>Meta description</source>
-        <target>Meta description</target>
+        <target>Méta-description</target>
       </segment>
     </unit>
     <unit id="2PqBQn1" name="Google snippet preview">

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -103,10 +103,10 @@
         <target><![CDATA[Utilisez-le pour remplacer la balise <tt>&lt;meta name="robots"&gt;</tt>]]></target>
       </segment>
     </unit>
-    <unit id="HxdlzS6" name="Use this to set the &lt;tt&gt;&amp;lt;meta name=&quot;og:type&quot;&amp;gt;&lt;/tt&gt;">
+    <unit id="AXJdT4M" name="Use this to set the &lt;tt&gt;&amp;lt;meta property=&quot;og:type&quot;&amp;gt;&lt;/tt&gt;">
       <segment>
-        <source>Use this to set the &lt;tt&gt;&amp;lt;meta name="og:type"&amp;gt;&lt;/tt&gt;</source>
-        <target><![CDATA[Utilisez ceci pour remplacer la balise <tt>&lt;meta name="og:type"&gt;</tt>]]></target>
+        <source>Use this to set the &lt;tt&gt;&amp;lt;meta property="og:type"&amp;gt;&lt;/tt&gt;</source>
+        <target><![CDATA[Utilisez ceci pour remplacer la balise <tt>&lt;meta property="og:type"&gt;</tt>]]></target>
       </segment>
     </unit>
     <unit id="z9KeyMt" name="Meta keywords">

--- a/translations/messages.hu.xlf
+++ b/translations/messages.hu.xlf
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="hu">
+  <file id="messages.hu">
+    <unit id="4TCRcpL" name="SEO Title">
+      <segment>
+        <source>SEO Title</source>
+        <target>SEO cím</target>
+      </segment>
+    </unit>
+    <unit id="3p.vSSI" name="Will be used as the &lt;tt&gt;&amp;lt;title&amp;gt;&lt;/tt&gt; and in search engines">
+      <segment>
+        <source>Will be used as the &lt;tt&gt;&amp;lt;title&amp;gt;&lt;/tt&gt; and in search engines</source>
+        <target><![CDATA[A <tt>&lt;title&gt;</tt> elemként és a keresőmotorokban lesz felhasználva]]></target>
+      </segment>
+    </unit>
+    <unit id="HdE0ldo" name="Limit the length to %number% characters">
+      <segment>
+        <source>Limit the length to %number% characters</source>
+        <target>Korlátozza a hosszúságot %number% karakterre</target>
+      </segment>
+    </unit>
+    <unit id="JPCo9LS" name="Meta description">
+      <segment>
+        <source>Meta description</source>
+        <target>Meta leírás</target>
+      </segment>
+    </unit>
+    <unit id="2PqBQn1" name="Google snippet preview">
+      <segment>
+        <source>Google snippet preview</source>
+        <target>Google kivonat előnézete</target>
+      </segment>
+    </unit>
+    <unit id="L.07lHq" name="Default title">
+      <segment>
+        <source>Default title</source>
+        <target>Alapértelmezett cím</target>
+      </segment>
+    </unit>
+    <unit id="lONBiUz" name="default-title">
+      <segment>
+        <source>default-title</source>
+        <target>alapertelmezett-cim</target>
+      </segment>
+    </unit>
+    <unit id="ORnQHm." name="Shortlink">
+      <segment>
+        <source>Shortlink</source>
+        <target>Rövid link</target>
+      </segment>
+    </unit>
+    <unit id="GgpqNso" name="alias">
+      <segment>
+        <source>alias</source>
+        <target>alias</target>
+      </segment>
+    </unit>
+    <unit id="..3kd27" name="Canonical Link">
+      <segment>
+        <source>Canonical Link</source>
+        <target>Kanonikus link</target>
+      </segment>
+    </unit>
+    <unit id="V.BIy_i" name="Use this to create an alias or shortlink to this record. Be sure to make it an absolute link">
+      <segment>
+        <source>Use this to create an alias or shortlink to this record. Be sure to make it an absolute link</source>
+        <target>Használja ezt aliasz vagy rövid link létrehozására ehhez a rekordhoz. Ügyeljen arra, hogy abszolút link legyen</target>
+      </segment>
+    </unit>
+    <unit id="FwLQ5cl" name="Use with caution, and only if you know what you're doing">
+      <segment>
+        <source>Use with caution, and only if you know what you're doing</source>
+        <target>Óvatosan használja, és csak akkor, ha tudja, mit csinál</target>
+      </segment>
+    </unit>
+    <unit id="n3BhrCh" name="Meta Robots Tag">
+      <segment>
+        <source>Meta Robots Tag</source>
+        <target>Meta Robots címke</target>
+      </segment>
+    </unit>
+    <unit id="JEVKWPy" name="Open Graph Type">
+      <segment>
+        <source>Open Graph Type</source>
+        <target>Open Graph típus</target>
+      </segment>
+    </unit>
+    <unit id="johNrI3" name="Leave blank for the default">
+      <segment>
+        <source>Leave blank for the default</source>
+        <target>Hagyja üresen az alapértelmezett értékhez</target>
+      </segment>
+    </unit>
+    <unit id="CJ8orGK" name="Will be used as the &lt;tt&gt;&amp;lt;meta name=&quot;description&quot;&amp;gt;&lt;/tt&gt;, and will show up in search engines">
+      <segment>
+        <source>Will be used as the &lt;tt&gt;&amp;lt;meta name="description"&amp;gt;&lt;/tt&gt;, and will show up in search engines</source>
+        <target><![CDATA[A <tt>&lt;meta name="description"&gt;</tt> elemként lesz felhasználva, és megjelenik a keresőmotorokban]]></target>
+      </segment>
+    </unit>
+    <unit id="0XJxYrt" name="Use this to override the &lt;tt&gt;&amp;lt;link rel=&quot;canonical&quot;&amp;gt;&lt;/tt&gt;">
+      <segment>
+        <source>Use this to override the &lt;tt&gt;&amp;lt;link rel="canonical"&amp;gt;&lt;/tt&gt;</source>
+        <target><![CDATA[Használja ezt a <tt>&lt;link rel="canonical"&gt;</tt> felülírásához]]></target>
+      </segment>
+    </unit>
+    <unit id="tGAPy_h" name="Use this to set the &lt;tt&gt;&amp;lt;meta name=&quot;robots&quot;&amp;gt;&lt;/tt&gt;">
+      <segment>
+        <source>Use this to set the &lt;tt&gt;&amp;lt;meta name="robots"&amp;gt;&lt;/tt&gt;</source>
+        <target><![CDATA[Használja ezt a <tt>&lt;meta name="robots"&gt;</tt> beállításához]]></target>
+      </segment>
+    </unit>
+    <unit id="AXJdT4M" name="Use this to set the &lt;tt&gt;&amp;lt;meta property=&quot;og:type&quot;&amp;gt;&lt;/tt&gt;">
+      <segment>
+        <source>Use this to set the &lt;tt&gt;&amp;lt;meta property="og:type"&amp;gt;&lt;/tt&gt;</source>
+        <target><![CDATA[Használja ezt a <tt>&lt;meta property="og:type"&gt;</tt> beállításához]]></target>
+      </segment>
+    </unit>
+    <unit id="z9KeyMt" name="Meta keywords">
+      <segment>
+        <source>Meta keywords</source>
+        <target>Meta kulcsszavak</target>
+      </segment>
+    </unit>
+    <unit id="z9KeyHl" name="Will be used as the &lt;tt&gt;&amp;lt;meta name=&quot;keywords&quot;&amp;gt;&lt;/tt&gt;, and will show up in &lt;em&gt;some&lt;/em&gt; search engines. Use comma separated tags only">
+      <segment>
+        <source>Will be used as the &lt;tt&gt;&amp;lt;meta name="keywords"&amp;gt;&lt;/tt&gt;, and will show up in &lt;em&gt;some&lt;/em&gt; search engines. Use comma separated tags only</source>
+        <target><![CDATA[A <tt>&lt;meta name="keywords"&gt;</tt> elemként lesz felhasználva, és megjelenik <em>néhány</em> keresőmotorban. Csak vesszővel elválasztott címkéket használjon]]></target>
+      </segment>
+    </unit>
+  </file>
+</xliff>

--- a/translations/messages.it.xlf
+++ b/translations/messages.it.xlf
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="it">
+  <file id="messages.it">
+    <unit id="4TCRcpL" name="SEO Title">
+      <segment>
+        <source>SEO Title</source>
+        <target>Titolo SEO</target>
+      </segment>
+    </unit>
+    <unit id="3p.vSSI" name="Will be used as the &lt;tt&gt;&amp;lt;title&amp;gt;&lt;/tt&gt; and in search engines">
+      <segment>
+        <source>Will be used as the &lt;tt&gt;&amp;lt;title&amp;gt;&lt;/tt&gt; and in search engines</source>
+        <target><![CDATA[Verrà utilizzato come <tt>&lt;title&gt;</tt> e nei motori di ricerca]]></target>
+      </segment>
+    </unit>
+    <unit id="HdE0ldo" name="Limit the length to %number% characters">
+      <segment>
+        <source>Limit the length to %number% characters</source>
+        <target>Limita la lunghezza a %number% caratteri</target>
+      </segment>
+    </unit>
+    <unit id="JPCo9LS" name="Meta description">
+      <segment>
+        <source>Meta description</source>
+        <target>Meta descrizione</target>
+      </segment>
+    </unit>
+    <unit id="2PqBQn1" name="Google snippet preview">
+      <segment>
+        <source>Google snippet preview</source>
+        <target>Anteprima dello snippet di Google</target>
+      </segment>
+    </unit>
+    <unit id="L.07lHq" name="Default title">
+      <segment>
+        <source>Default title</source>
+        <target>Titolo predefinito</target>
+      </segment>
+    </unit>
+    <unit id="lONBiUz" name="default-title">
+      <segment>
+        <source>default-title</source>
+        <target>titolo-predefinito</target>
+      </segment>
+    </unit>
+    <unit id="ORnQHm." name="Shortlink">
+      <segment>
+        <source>Shortlink</source>
+        <target>Link breve</target>
+      </segment>
+    </unit>
+    <unit id="GgpqNso" name="alias">
+      <segment>
+        <source>alias</source>
+        <target>alias</target>
+      </segment>
+    </unit>
+    <unit id="..3kd27" name="Canonical Link">
+      <segment>
+        <source>Canonical Link</source>
+        <target>Link canonico</target>
+      </segment>
+    </unit>
+    <unit id="V.BIy_i" name="Use this to create an alias or shortlink to this record. Be sure to make it an absolute link">
+      <segment>
+        <source>Use this to create an alias or shortlink to this record. Be sure to make it an absolute link</source>
+        <target>Usalo per creare un alias o un link breve a questo record. Assicurati che sia un link assoluto</target>
+      </segment>
+    </unit>
+    <unit id="FwLQ5cl" name="Use with caution, and only if you know what you're doing">
+      <segment>
+        <source>Use with caution, and only if you know what you're doing</source>
+        <target>Usare con cautela e solo se sai cosa stai facendo</target>
+      </segment>
+    </unit>
+    <unit id="n3BhrCh" name="Meta Robots Tag">
+      <segment>
+        <source>Meta Robots Tag</source>
+        <target>Tag Meta Robots</target>
+      </segment>
+    </unit>
+    <unit id="JEVKWPy" name="Open Graph Type">
+      <segment>
+        <source>Open Graph Type</source>
+        <target>Tipo Open Graph</target>
+      </segment>
+    </unit>
+    <unit id="johNrI3" name="Leave blank for the default">
+      <segment>
+        <source>Leave blank for the default</source>
+        <target>Lascia vuoto per il valore predefinito</target>
+      </segment>
+    </unit>
+    <unit id="CJ8orGK" name="Will be used as the &lt;tt&gt;&amp;lt;meta name=&quot;description&quot;&amp;gt;&lt;/tt&gt;, and will show up in search engines">
+      <segment>
+        <source>Will be used as the &lt;tt&gt;&amp;lt;meta name="description"&amp;gt;&lt;/tt&gt;, and will show up in search engines</source>
+        <target><![CDATA[Verrà utilizzato come <tt>&lt;meta name="description"&gt;</tt> e apparirà nei motori di ricerca]]></target>
+      </segment>
+    </unit>
+    <unit id="0XJxYrt" name="Use this to override the &lt;tt&gt;&amp;lt;link rel=&quot;canonical&quot;&amp;gt;&lt;/tt&gt;">
+      <segment>
+        <source>Use this to override the &lt;tt&gt;&amp;lt;link rel="canonical"&amp;gt;&lt;/tt&gt;</source>
+        <target><![CDATA[Usalo per sovrascrivere il <tt>&lt;link rel="canonical"&gt;</tt>]]></target>
+      </segment>
+    </unit>
+    <unit id="tGAPy_h" name="Use this to set the &lt;tt&gt;&amp;lt;meta name=&quot;robots&quot;&amp;gt;&lt;/tt&gt;">
+      <segment>
+        <source>Use this to set the &lt;tt&gt;&amp;lt;meta name="robots"&amp;gt;&lt;/tt&gt;</source>
+        <target><![CDATA[Usalo per impostare il <tt>&lt;meta name="robots"&gt;</tt>]]></target>
+      </segment>
+    </unit>
+    <unit id="AXJdT4M" name="Use this to set the &lt;tt&gt;&amp;lt;meta property=&quot;og:type&quot;&amp;gt;&lt;/tt&gt;">
+      <segment>
+        <source>Use this to set the &lt;tt&gt;&amp;lt;meta property="og:type"&amp;gt;&lt;/tt&gt;</source>
+        <target><![CDATA[Usalo per impostare il <tt>&lt;meta property="og:type"&gt;</tt>]]></target>
+      </segment>
+    </unit>
+    <unit id="z9KeyMt" name="Meta keywords">
+      <segment>
+        <source>Meta keywords</source>
+        <target>Meta parole chiave</target>
+      </segment>
+    </unit>
+    <unit id="z9KeyHl" name="Will be used as the &lt;tt&gt;&amp;lt;meta name=&quot;keywords&quot;&amp;gt;&lt;/tt&gt;, and will show up in &lt;em&gt;some&lt;/em&gt; search engines. Use comma separated tags only">
+      <segment>
+        <source>Will be used as the &lt;tt&gt;&amp;lt;meta name="keywords"&amp;gt;&lt;/tt&gt;, and will show up in &lt;em&gt;some&lt;/em&gt; search engines. Use comma separated tags only</source>
+        <target><![CDATA[Verrà utilizzato come <tt>&lt;meta name="keywords"&gt;</tt> e apparirà in <em>alcuni</em> motori di ricerca. Usa solo tag separati da virgole]]></target>
+      </segment>
+    </unit>
+  </file>
+</xliff>

--- a/translations/messages.nl.xlf
+++ b/translations/messages.nl.xlf
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="nl">
+  <file id="messages.nl">
+    <unit id="4TCRcpL" name="SEO Title">
+      <segment>
+        <source>SEO Title</source>
+        <target>SEO-titel</target>
+      </segment>
+    </unit>
+    <unit id="3p.vSSI" name="Will be used as the &lt;tt&gt;&amp;lt;title&amp;gt;&lt;/tt&gt; and in search engines">
+      <segment>
+        <source>Will be used as the &lt;tt&gt;&amp;lt;title&amp;gt;&lt;/tt&gt; and in search engines</source>
+        <target><![CDATA[Wordt gebruikt als de <tt>&lt;title&gt;</tt> en in zoekmachines]]></target>
+      </segment>
+    </unit>
+    <unit id="HdE0ldo" name="Limit the length to %number% characters">
+      <segment>
+        <source>Limit the length to %number% characters</source>
+        <target>Beperk de lengte tot %number% tekens</target>
+      </segment>
+    </unit>
+    <unit id="JPCo9LS" name="Meta description">
+      <segment>
+        <source>Meta description</source>
+        <target>Metabeschrijving</target>
+      </segment>
+    </unit>
+    <unit id="2PqBQn1" name="Google snippet preview">
+      <segment>
+        <source>Google snippet preview</source>
+        <target>Google snippet-voorbeeld</target>
+      </segment>
+    </unit>
+    <unit id="L.07lHq" name="Default title">
+      <segment>
+        <source>Default title</source>
+        <target>Standaardtitel</target>
+      </segment>
+    </unit>
+    <unit id="lONBiUz" name="default-title">
+      <segment>
+        <source>default-title</source>
+        <target>standaardtitel</target>
+      </segment>
+    </unit>
+    <unit id="ORnQHm." name="Shortlink">
+      <segment>
+        <source>Shortlink</source>
+        <target>Verkorte link</target>
+      </segment>
+    </unit>
+    <unit id="GgpqNso" name="alias">
+      <segment>
+        <source>alias</source>
+        <target>alias</target>
+      </segment>
+    </unit>
+    <unit id="..3kd27" name="Canonical Link">
+      <segment>
+        <source>Canonical Link</source>
+        <target>Canonieke link</target>
+      </segment>
+    </unit>
+    <unit id="V.BIy_i" name="Use this to create an alias or shortlink to this record. Be sure to make it an absolute link">
+      <segment>
+        <source>Use this to create an alias or shortlink to this record. Be sure to make it an absolute link</source>
+        <target>Gebruik dit om een alias of verkorte link naar dit record te maken. Zorg ervoor dat het een absolute link is</target>
+      </segment>
+    </unit>
+    <unit id="FwLQ5cl" name="Use with caution, and only if you know what you're doing">
+      <segment>
+        <source>Use with caution, and only if you know what you're doing</source>
+        <target>Gebruik met voorzichtigheid en alleen als je weet wat je doet</target>
+      </segment>
+    </unit>
+    <unit id="n3BhrCh" name="Meta Robots Tag">
+      <segment>
+        <source>Meta Robots Tag</source>
+        <target>Meta Robots-tag</target>
+      </segment>
+    </unit>
+    <unit id="JEVKWPy" name="Open Graph Type">
+      <segment>
+        <source>Open Graph Type</source>
+        <target>Open Graph-type</target>
+      </segment>
+    </unit>
+    <unit id="johNrI3" name="Leave blank for the default">
+      <segment>
+        <source>Leave blank for the default</source>
+        <target>Laat leeg voor de standaardwaarde</target>
+      </segment>
+    </unit>
+    <unit id="CJ8orGK" name="Will be used as the &lt;tt&gt;&amp;lt;meta name=&quot;description&quot;&amp;gt;&lt;/tt&gt;, and will show up in search engines">
+      <segment>
+        <source>Will be used as the &lt;tt&gt;&amp;lt;meta name="description"&amp;gt;&lt;/tt&gt;, and will show up in search engines</source>
+        <target><![CDATA[Wordt gebruikt als de <tt>&lt;meta name="description"&gt;</tt> en verschijnt in zoekmachines]]></target>
+      </segment>
+    </unit>
+    <unit id="0XJxYrt" name="Use this to override the &lt;tt&gt;&amp;lt;link rel=&quot;canonical&quot;&amp;gt;&lt;/tt&gt;">
+      <segment>
+        <source>Use this to override the &lt;tt&gt;&amp;lt;link rel="canonical"&amp;gt;&lt;/tt&gt;</source>
+        <target><![CDATA[Gebruik dit om de <tt>&lt;link rel="canonical"&gt;</tt> te overschrijven]]></target>
+      </segment>
+    </unit>
+    <unit id="tGAPy_h" name="Use this to set the &lt;tt&gt;&amp;lt;meta name=&quot;robots&quot;&amp;gt;&lt;/tt&gt;">
+      <segment>
+        <source>Use this to set the &lt;tt&gt;&amp;lt;meta name="robots"&amp;gt;&lt;/tt&gt;</source>
+        <target><![CDATA[Gebruik dit om de <tt>&lt;meta name="robots"&gt;</tt> in te stellen]]></target>
+      </segment>
+    </unit>
+    <unit id="AXJdT4M" name="Use this to set the &lt;tt&gt;&amp;lt;meta property=&quot;og:type&quot;&amp;gt;&lt;/tt&gt;">
+      <segment>
+        <source>Use this to set the &lt;tt&gt;&amp;lt;meta property="og:type"&amp;gt;&lt;/tt&gt;</source>
+        <target><![CDATA[Gebruik dit om de <tt>&lt;meta property="og:type"&gt;</tt> in te stellen]]></target>
+      </segment>
+    </unit>
+    <unit id="z9KeyMt" name="Meta keywords">
+      <segment>
+        <source>Meta keywords</source>
+        <target>Meta-trefwoorden</target>
+      </segment>
+    </unit>
+    <unit id="z9KeyHl" name="Will be used as the &lt;tt&gt;&amp;lt;meta name=&quot;keywords&quot;&amp;gt;&lt;/tt&gt;, and will show up in &lt;em&gt;some&lt;/em&gt; search engines. Use comma separated tags only">
+      <segment>
+        <source>Will be used as the &lt;tt&gt;&amp;lt;meta name="keywords"&amp;gt;&lt;/tt&gt;, and will show up in &lt;em&gt;some&lt;/em&gt; search engines. Use comma separated tags only</source>
+        <target><![CDATA[Wordt gebruikt als de <tt>&lt;meta name="keywords"&gt;</tt> en verschijnt in <em>sommige</em> zoekmachines. Gebruik alleen door komma's gescheiden tags]]></target>
+      </segment>
+    </unit>
+  </file>
+</xliff>

--- a/translations/messages.pl.xlf
+++ b/translations/messages.pl.xlf
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="pl">
+  <file id="messages.pl">
+    <unit id="4TCRcpL" name="SEO Title">
+      <segment>
+        <source>SEO Title</source>
+        <target>Tytuł SEO</target>
+      </segment>
+    </unit>
+    <unit id="3p.vSSI" name="Will be used as the &lt;tt&gt;&amp;lt;title&amp;gt;&lt;/tt&gt; and in search engines">
+      <segment>
+        <source>Will be used as the &lt;tt&gt;&amp;lt;title&amp;gt;&lt;/tt&gt; and in search engines</source>
+        <target><![CDATA[Zostanie użyty jako <tt>&lt;title&gt;</tt> oraz w wyszukiwarkach]]></target>
+      </segment>
+    </unit>
+    <unit id="HdE0ldo" name="Limit the length to %number% characters">
+      <segment>
+        <source>Limit the length to %number% characters</source>
+        <target>Ogranicz długość do %number% znaków</target>
+      </segment>
+    </unit>
+    <unit id="JPCo9LS" name="Meta description">
+      <segment>
+        <source>Meta description</source>
+        <target>Meta opis</target>
+      </segment>
+    </unit>
+    <unit id="2PqBQn1" name="Google snippet preview">
+      <segment>
+        <source>Google snippet preview</source>
+        <target>Podgląd fragmentu Google</target>
+      </segment>
+    </unit>
+    <unit id="L.07lHq" name="Default title">
+      <segment>
+        <source>Default title</source>
+        <target>Domyślny tytuł</target>
+      </segment>
+    </unit>
+    <unit id="lONBiUz" name="default-title">
+      <segment>
+        <source>default-title</source>
+        <target>domyslny-tytul</target>
+      </segment>
+    </unit>
+    <unit id="ORnQHm." name="Shortlink">
+      <segment>
+        <source>Shortlink</source>
+        <target>Krótki link</target>
+      </segment>
+    </unit>
+    <unit id="GgpqNso" name="alias">
+      <segment>
+        <source>alias</source>
+        <target>alias</target>
+      </segment>
+    </unit>
+    <unit id="..3kd27" name="Canonical Link">
+      <segment>
+        <source>Canonical Link</source>
+        <target>Link kanoniczny</target>
+      </segment>
+    </unit>
+    <unit id="V.BIy_i" name="Use this to create an alias or shortlink to this record. Be sure to make it an absolute link">
+      <segment>
+        <source>Use this to create an alias or shortlink to this record. Be sure to make it an absolute link</source>
+        <target>Użyj tego, aby utworzyć alias lub krótki link do tego rekordu. Upewnij się, że jest to link bezwzględny</target>
+      </segment>
+    </unit>
+    <unit id="FwLQ5cl" name="Use with caution, and only if you know what you're doing">
+      <segment>
+        <source>Use with caution, and only if you know what you're doing</source>
+        <target>Używaj ostrożnie i tylko jeśli wiesz, co robisz</target>
+      </segment>
+    </unit>
+    <unit id="n3BhrCh" name="Meta Robots Tag">
+      <segment>
+        <source>Meta Robots Tag</source>
+        <target>Meta tag Robots</target>
+      </segment>
+    </unit>
+    <unit id="JEVKWPy" name="Open Graph Type">
+      <segment>
+        <source>Open Graph Type</source>
+        <target>Typ Open Graph</target>
+      </segment>
+    </unit>
+    <unit id="johNrI3" name="Leave blank for the default">
+      <segment>
+        <source>Leave blank for the default</source>
+        <target>Pozostaw puste, aby użyć wartości domyślnej</target>
+      </segment>
+    </unit>
+    <unit id="CJ8orGK" name="Will be used as the &lt;tt&gt;&amp;lt;meta name=&quot;description&quot;&amp;gt;&lt;/tt&gt;, and will show up in search engines">
+      <segment>
+        <source>Will be used as the &lt;tt&gt;&amp;lt;meta name="description"&amp;gt;&lt;/tt&gt;, and will show up in search engines</source>
+        <target><![CDATA[Zostanie użyty jako <tt>&lt;meta name="description"&gt;</tt> i pojawi się w wyszukiwarkach]]></target>
+      </segment>
+    </unit>
+    <unit id="0XJxYrt" name="Use this to override the &lt;tt&gt;&amp;lt;link rel=&quot;canonical&quot;&amp;gt;&lt;/tt&gt;">
+      <segment>
+        <source>Use this to override the &lt;tt&gt;&amp;lt;link rel="canonical"&amp;gt;&lt;/tt&gt;</source>
+        <target><![CDATA[Użyj tego, aby zastąpić <tt>&lt;link rel="canonical"&gt;</tt>]]></target>
+      </segment>
+    </unit>
+    <unit id="tGAPy_h" name="Use this to set the &lt;tt&gt;&amp;lt;meta name=&quot;robots&quot;&amp;gt;&lt;/tt&gt;">
+      <segment>
+        <source>Use this to set the &lt;tt&gt;&amp;lt;meta name="robots"&amp;gt;&lt;/tt&gt;</source>
+        <target><![CDATA[Użyj tego, aby ustawić <tt>&lt;meta name="robots"&gt;</tt>]]></target>
+      </segment>
+    </unit>
+    <unit id="AXJdT4M" name="Use this to set the &lt;tt&gt;&amp;lt;meta property=&quot;og:type&quot;&amp;gt;&lt;/tt&gt;">
+      <segment>
+        <source>Use this to set the &lt;tt&gt;&amp;lt;meta property="og:type"&amp;gt;&lt;/tt&gt;</source>
+        <target><![CDATA[Użyj tego, aby ustawić <tt>&lt;meta property="og:type"&gt;</tt>]]></target>
+      </segment>
+    </unit>
+    <unit id="z9KeyMt" name="Meta keywords">
+      <segment>
+        <source>Meta keywords</source>
+        <target>Meta słowa kluczowe</target>
+      </segment>
+    </unit>
+    <unit id="z9KeyHl" name="Will be used as the &lt;tt&gt;&amp;lt;meta name=&quot;keywords&quot;&amp;gt;&lt;/tt&gt;, and will show up in &lt;em&gt;some&lt;/em&gt; search engines. Use comma separated tags only">
+      <segment>
+        <source>Will be used as the &lt;tt&gt;&amp;lt;meta name="keywords"&amp;gt;&lt;/tt&gt;, and will show up in &lt;em&gt;some&lt;/em&gt; search engines. Use comma separated tags only</source>
+        <target><![CDATA[Zostanie użyty jako <tt>&lt;meta name="keywords"&gt;</tt> i pojawi się w <em>niektórych</em> wyszukiwarkach. Używaj tylko tagów oddzielonych przecinkami]]></target>
+      </segment>
+    </unit>
+  </file>
+</xliff>

--- a/translations/messages.pt.xlf
+++ b/translations/messages.pt.xlf
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="pt">
+  <file id="messages.pt">
+    <unit id="4TCRcpL" name="SEO Title">
+      <segment>
+        <source>SEO Title</source>
+        <target>Título SEO</target>
+      </segment>
+    </unit>
+    <unit id="3p.vSSI" name="Will be used as the &lt;tt&gt;&amp;lt;title&amp;gt;&lt;/tt&gt; and in search engines">
+      <segment>
+        <source>Will be used as the &lt;tt&gt;&amp;lt;title&amp;gt;&lt;/tt&gt; and in search engines</source>
+        <target><![CDATA[Será usado como <tt>&lt;title&gt;</tt> e nos motores de busca]]></target>
+      </segment>
+    </unit>
+    <unit id="HdE0ldo" name="Limit the length to %number% characters">
+      <segment>
+        <source>Limit the length to %number% characters</source>
+        <target>Limite o comprimento a %number% caracteres</target>
+      </segment>
+    </unit>
+    <unit id="JPCo9LS" name="Meta description">
+      <segment>
+        <source>Meta description</source>
+        <target>Meta descrição</target>
+      </segment>
+    </unit>
+    <unit id="2PqBQn1" name="Google snippet preview">
+      <segment>
+        <source>Google snippet preview</source>
+        <target>Pré-visualização do snippet do Google</target>
+      </segment>
+    </unit>
+    <unit id="L.07lHq" name="Default title">
+      <segment>
+        <source>Default title</source>
+        <target>Título predefinido</target>
+      </segment>
+    </unit>
+    <unit id="lONBiUz" name="default-title">
+      <segment>
+        <source>default-title</source>
+        <target>titulo-predefinido</target>
+      </segment>
+    </unit>
+    <unit id="ORnQHm." name="Shortlink">
+      <segment>
+        <source>Shortlink</source>
+        <target>Link curto</target>
+      </segment>
+    </unit>
+    <unit id="GgpqNso" name="alias">
+      <segment>
+        <source>alias</source>
+        <target>alias</target>
+      </segment>
+    </unit>
+    <unit id="..3kd27" name="Canonical Link">
+      <segment>
+        <source>Canonical Link</source>
+        <target>Link canónico</target>
+      </segment>
+    </unit>
+    <unit id="V.BIy_i" name="Use this to create an alias or shortlink to this record. Be sure to make it an absolute link">
+      <segment>
+        <source>Use this to create an alias or shortlink to this record. Be sure to make it an absolute link</source>
+        <target>Use isto para criar um alias ou link curto para este registo. Certifique-se de que é um link absoluto</target>
+      </segment>
+    </unit>
+    <unit id="FwLQ5cl" name="Use with caution, and only if you know what you're doing">
+      <segment>
+        <source>Use with caution, and only if you know what you're doing</source>
+        <target>Use com cuidado e apenas se souber o que está a fazer</target>
+      </segment>
+    </unit>
+    <unit id="n3BhrCh" name="Meta Robots Tag">
+      <segment>
+        <source>Meta Robots Tag</source>
+        <target>Tag Meta Robots</target>
+      </segment>
+    </unit>
+    <unit id="JEVKWPy" name="Open Graph Type">
+      <segment>
+        <source>Open Graph Type</source>
+        <target>Tipo Open Graph</target>
+      </segment>
+    </unit>
+    <unit id="johNrI3" name="Leave blank for the default">
+      <segment>
+        <source>Leave blank for the default</source>
+        <target>Deixe em branco para o valor predefinido</target>
+      </segment>
+    </unit>
+    <unit id="CJ8orGK" name="Will be used as the &lt;tt&gt;&amp;lt;meta name=&quot;description&quot;&amp;gt;&lt;/tt&gt;, and will show up in search engines">
+      <segment>
+        <source>Will be used as the &lt;tt&gt;&amp;lt;meta name="description"&amp;gt;&lt;/tt&gt;, and will show up in search engines</source>
+        <target><![CDATA[Será usado como <tt>&lt;meta name="description"&gt;</tt> e aparecerá nos motores de busca]]></target>
+      </segment>
+    </unit>
+    <unit id="0XJxYrt" name="Use this to override the &lt;tt&gt;&amp;lt;link rel=&quot;canonical&quot;&amp;gt;&lt;/tt&gt;">
+      <segment>
+        <source>Use this to override the &lt;tt&gt;&amp;lt;link rel="canonical"&amp;gt;&lt;/tt&gt;</source>
+        <target><![CDATA[Use isto para substituir o <tt>&lt;link rel="canonical"&gt;</tt>]]></target>
+      </segment>
+    </unit>
+    <unit id="tGAPy_h" name="Use this to set the &lt;tt&gt;&amp;lt;meta name=&quot;robots&quot;&amp;gt;&lt;/tt&gt;">
+      <segment>
+        <source>Use this to set the &lt;tt&gt;&amp;lt;meta name="robots"&amp;gt;&lt;/tt&gt;</source>
+        <target><![CDATA[Use isto para definir o <tt>&lt;meta name="robots"&gt;</tt>]]></target>
+      </segment>
+    </unit>
+    <unit id="AXJdT4M" name="Use this to set the &lt;tt&gt;&amp;lt;meta property=&quot;og:type&quot;&amp;gt;&lt;/tt&gt;">
+      <segment>
+        <source>Use this to set the &lt;tt&gt;&amp;lt;meta property="og:type"&amp;gt;&lt;/tt&gt;</source>
+        <target><![CDATA[Use isto para definir o <tt>&lt;meta property="og:type"&gt;</tt>]]></target>
+      </segment>
+    </unit>
+    <unit id="z9KeyMt" name="Meta keywords">
+      <segment>
+        <source>Meta keywords</source>
+        <target>Meta palavras-chave</target>
+      </segment>
+    </unit>
+    <unit id="z9KeyHl" name="Will be used as the &lt;tt&gt;&amp;lt;meta name=&quot;keywords&quot;&amp;gt;&lt;/tt&gt;, and will show up in &lt;em&gt;some&lt;/em&gt; search engines. Use comma separated tags only">
+      <segment>
+        <source>Will be used as the &lt;tt&gt;&amp;lt;meta name="keywords"&amp;gt;&lt;/tt&gt;, and will show up in &lt;em&gt;some&lt;/em&gt; search engines. Use comma separated tags only</source>
+        <target><![CDATA[Será usado como <tt>&lt;meta name="keywords"&gt;</tt> e aparecerá em <em>alguns</em> motores de busca. Use apenas etiquetas separadas por vírgulas]]></target>
+      </segment>
+    </unit>
+  </file>
+</xliff>

--- a/translations/messages.ro.xlf
+++ b/translations/messages.ro.xlf
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="ro">
+  <file id="messages.ro">
+    <unit id="4TCRcpL" name="SEO Title">
+      <segment>
+        <source>SEO Title</source>
+        <target>Titlu SEO</target>
+      </segment>
+    </unit>
+    <unit id="3p.vSSI" name="Will be used as the &lt;tt&gt;&amp;lt;title&amp;gt;&lt;/tt&gt; and in search engines">
+      <segment>
+        <source>Will be used as the &lt;tt&gt;&amp;lt;title&amp;gt;&lt;/tt&gt; and in search engines</source>
+        <target><![CDATA[Va fi folosit ca <tt>&lt;title&gt;</tt> și în motoarele de căutare]]></target>
+      </segment>
+    </unit>
+    <unit id="HdE0ldo" name="Limit the length to %number% characters">
+      <segment>
+        <source>Limit the length to %number% characters</source>
+        <target>Limitați lungimea la %number% caractere</target>
+      </segment>
+    </unit>
+    <unit id="JPCo9LS" name="Meta description">
+      <segment>
+        <source>Meta description</source>
+        <target>Meta descriere</target>
+      </segment>
+    </unit>
+    <unit id="2PqBQn1" name="Google snippet preview">
+      <segment>
+        <source>Google snippet preview</source>
+        <target>Previzualizare fragment Google</target>
+      </segment>
+    </unit>
+    <unit id="L.07lHq" name="Default title">
+      <segment>
+        <source>Default title</source>
+        <target>Titlu implicit</target>
+      </segment>
+    </unit>
+    <unit id="lONBiUz" name="default-title">
+      <segment>
+        <source>default-title</source>
+        <target>titlu-implicit</target>
+      </segment>
+    </unit>
+    <unit id="ORnQHm." name="Shortlink">
+      <segment>
+        <source>Shortlink</source>
+        <target>Link scurt</target>
+      </segment>
+    </unit>
+    <unit id="GgpqNso" name="alias">
+      <segment>
+        <source>alias</source>
+        <target>alias</target>
+      </segment>
+    </unit>
+    <unit id="..3kd27" name="Canonical Link">
+      <segment>
+        <source>Canonical Link</source>
+        <target>Link canonic</target>
+      </segment>
+    </unit>
+    <unit id="V.BIy_i" name="Use this to create an alias or shortlink to this record. Be sure to make it an absolute link">
+      <segment>
+        <source>Use this to create an alias or shortlink to this record. Be sure to make it an absolute link</source>
+        <target>Folosiți acest câmp pentru a crea un alias sau un link scurt către această înregistrare. Asigurați-vă că este un link absolut</target>
+      </segment>
+    </unit>
+    <unit id="FwLQ5cl" name="Use with caution, and only if you know what you're doing">
+      <segment>
+        <source>Use with caution, and only if you know what you're doing</source>
+        <target>Folosiți cu precauție și numai dacă știți ce faceți</target>
+      </segment>
+    </unit>
+    <unit id="n3BhrCh" name="Meta Robots Tag">
+      <segment>
+        <source>Meta Robots Tag</source>
+        <target>Etichetă Meta Robots</target>
+      </segment>
+    </unit>
+    <unit id="JEVKWPy" name="Open Graph Type">
+      <segment>
+        <source>Open Graph Type</source>
+        <target>Tip Open Graph</target>
+      </segment>
+    </unit>
+    <unit id="johNrI3" name="Leave blank for the default">
+      <segment>
+        <source>Leave blank for the default</source>
+        <target>Lăsați gol pentru valoarea implicită</target>
+      </segment>
+    </unit>
+    <unit id="CJ8orGK" name="Will be used as the &lt;tt&gt;&amp;lt;meta name=&quot;description&quot;&amp;gt;&lt;/tt&gt;, and will show up in search engines">
+      <segment>
+        <source>Will be used as the &lt;tt&gt;&amp;lt;meta name="description"&amp;gt;&lt;/tt&gt;, and will show up in search engines</source>
+        <target><![CDATA[Va fi folosit ca <tt>&lt;meta name="description"&gt;</tt> și va apărea în motoarele de căutare]]></target>
+      </segment>
+    </unit>
+    <unit id="0XJxYrt" name="Use this to override the &lt;tt&gt;&amp;lt;link rel=&quot;canonical&quot;&amp;gt;&lt;/tt&gt;">
+      <segment>
+        <source>Use this to override the &lt;tt&gt;&amp;lt;link rel="canonical"&amp;gt;&lt;/tt&gt;</source>
+        <target><![CDATA[Folosiți acest câmp pentru a suprascrie <tt>&lt;link rel="canonical"&gt;</tt>]]></target>
+      </segment>
+    </unit>
+    <unit id="tGAPy_h" name="Use this to set the &lt;tt&gt;&amp;lt;meta name=&quot;robots&quot;&amp;gt;&lt;/tt&gt;">
+      <segment>
+        <source>Use this to set the &lt;tt&gt;&amp;lt;meta name="robots"&amp;gt;&lt;/tt&gt;</source>
+        <target><![CDATA[Folosiți acest câmp pentru a seta <tt>&lt;meta name="robots"&gt;</tt>]]></target>
+      </segment>
+    </unit>
+    <unit id="AXJdT4M" name="Use this to set the &lt;tt&gt;&amp;lt;meta property=&quot;og:type&quot;&amp;gt;&lt;/tt&gt;">
+      <segment>
+        <source>Use this to set the &lt;tt&gt;&amp;lt;meta property="og:type"&amp;gt;&lt;/tt&gt;</source>
+        <target><![CDATA[Folosiți acest câmp pentru a seta <tt>&lt;meta property="og:type"&gt;</tt>]]></target>
+      </segment>
+    </unit>
+    <unit id="z9KeyMt" name="Meta keywords">
+      <segment>
+        <source>Meta keywords</source>
+        <target>Meta cuvinte cheie</target>
+      </segment>
+    </unit>
+    <unit id="z9KeyHl" name="Will be used as the &lt;tt&gt;&amp;lt;meta name=&quot;keywords&quot;&amp;gt;&lt;/tt&gt;, and will show up in &lt;em&gt;some&lt;/em&gt; search engines. Use comma separated tags only">
+      <segment>
+        <source>Will be used as the &lt;tt&gt;&amp;lt;meta name="keywords"&amp;gt;&lt;/tt&gt;, and will show up in &lt;em&gt;some&lt;/em&gt; search engines. Use comma separated tags only</source>
+        <target><![CDATA[Va fi folosit ca <tt>&lt;meta name="keywords"&gt;</tt> și va apărea în <em>unele</em> motoare de căutare. Folosiți doar etichete separate prin virgulă]]></target>
+      </segment>
+    </unit>
+  </file>
+</xliff>

--- a/translations/messages.ru.xlf
+++ b/translations/messages.ru.xlf
@@ -28,7 +28,7 @@
     <unit id="2PqBQn1" name="Google snippet preview">
       <segment>
         <source>Google snippet preview</source>
-        <target>Google сниппет предварительного просмотра фрагмента</target>
+        <target>Предварительный просмотр сниппета Google</target>
       </segment>
     </unit>
     <unit id="L.07lHq" name="Default title">
@@ -70,7 +70,7 @@
     <unit id="FwLQ5cl" name="Use with caution, and only if you know what you're doing">
       <segment>
         <source>Use with caution, and only if you know what you're doing</source>
-        <target>Используйте с осторожностью и только если вы знаете, что делаете.</target>
+        <target>Используйте с осторожностью и только если вы знаете, что делаете</target>
       </segment>
     </unit>
     <unit id="n3BhrCh" name="Meta Robots Tag">
@@ -88,7 +88,7 @@
     <unit id="johNrI3" name="Leave blank for the default">
       <segment>
         <source>Leave blank for the default</source>
-        <target>Оставьте поле пустым для использования по умолчанию.</target>
+        <target>Оставьте поле пустым для использования по умолчанию</target>
       </segment>
     </unit>
     <unit id="CJ8orGK" name="Will be used as the &lt;tt&gt;&amp;lt;meta name=&quot;description&quot;&amp;gt;&lt;/tt&gt;, and will show up in search engines">

--- a/translations/messages.ru.xlf
+++ b/translations/messages.ru.xlf
@@ -37,6 +37,12 @@
         <target>Заголовок по умолчанию</target>
       </segment>
     </unit>
+    <unit id="lONBiUz" name="default-title">
+      <segment>
+        <source>default-title</source>
+        <target>zagolovok-po-umolchaniyu</target>
+      </segment>
+    </unit>
     <unit id="ORnQHm." name="Shortlink">
       <segment>
         <source>Shortlink</source>

--- a/translations/messages.ru.xlf
+++ b/translations/messages.ru.xlf
@@ -103,10 +103,10 @@
         <target><![CDATA[Используйте это, чтобы задать <tt>&lt;meta name="robots"&gt;</tt>]]></target>
       </segment>
     </unit>
-    <unit id="HxdlzS6" name="Use this to set the &lt;tt&gt;&amp;lt;meta name=&quot;og:type&quot;&amp;gt;&lt;/tt&gt;">
+    <unit id="AXJdT4M" name="Use this to set the &lt;tt&gt;&amp;lt;meta property=&quot;og:type&quot;&amp;gt;&lt;/tt&gt;">
       <segment>
-        <source>Use this to set the &lt;tt&gt;&amp;lt;meta name="og:type"&amp;gt;&lt;/tt&gt;</source>
-        <target><![CDATA[Используйте это, чтобы задать <tt>&lt;meta name="og:type"&gt;</tt>]]></target>
+        <source>Use this to set the &lt;tt&gt;&amp;lt;meta property="og:type"&amp;gt;&lt;/tt&gt;</source>
+        <target><![CDATA[Используйте это, чтобы задать <tt>&lt;meta property="og:type"&gt;</tt>]]></target>
       </segment>
     </unit>
     <unit id="z9KeyMt" name="Meta keywords">

--- a/translations/messages.ru.xlf
+++ b/translations/messages.ru.xlf
@@ -61,10 +61,10 @@
         <target>Каноническая ссылка</target>
       </segment>
     </unit>
-    <unit id="pCpmxa8" name="Use this to create an alias or shortlink to this record. Be sure to make it an absolute link.">
+    <unit id="V.BIy_i" name="Use this to create an alias or shortlink to this record. Be sure to make it an absolute link">
       <segment>
-        <source>Use this to create an alias or shortlink to this record. Be sure to make it an absolute link.</source>
-        <target>Используйте это, чтобы создать псевдоним или короткую ссылку на эту запись. Обязательно сделайте это абсолютной ссылкой.</target>
+        <source>Use this to create an alias or shortlink to this record. Be sure to make it an absolute link</source>
+        <target>Используйте это, чтобы создать псевдоним или короткую ссылку на эту запись. Обязательно сделайте это абсолютной ссылкой</target>
       </segment>
     </unit>
     <unit id="FwLQ5cl" name="Use with caution, and only if you know what you're doing">

--- a/translations/messages.sk.xlf
+++ b/translations/messages.sk.xlf
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="sk">
+  <file id="messages.sk">
+    <unit id="4TCRcpL" name="SEO Title">
+      <segment>
+        <source>SEO Title</source>
+        <target>SEO titulok</target>
+      </segment>
+    </unit>
+    <unit id="3p.vSSI" name="Will be used as the &lt;tt&gt;&amp;lt;title&amp;gt;&lt;/tt&gt; and in search engines">
+      <segment>
+        <source>Will be used as the &lt;tt&gt;&amp;lt;title&amp;gt;&lt;/tt&gt; and in search engines</source>
+        <target><![CDATA[Bude použité ako <tt>&lt;title&gt;</tt> a vo vyhľadávačoch]]></target>
+      </segment>
+    </unit>
+    <unit id="HdE0ldo" name="Limit the length to %number% characters">
+      <segment>
+        <source>Limit the length to %number% characters</source>
+        <target>Obmedzte dĺžku na %number% znakov</target>
+      </segment>
+    </unit>
+    <unit id="JPCo9LS" name="Meta description">
+      <segment>
+        <source>Meta description</source>
+        <target>Meta popis</target>
+      </segment>
+    </unit>
+    <unit id="2PqBQn1" name="Google snippet preview">
+      <segment>
+        <source>Google snippet preview</source>
+        <target>Náhľad úryvku Google</target>
+      </segment>
+    </unit>
+    <unit id="L.07lHq" name="Default title">
+      <segment>
+        <source>Default title</source>
+        <target>Predvolený titulok</target>
+      </segment>
+    </unit>
+    <unit id="lONBiUz" name="default-title">
+      <segment>
+        <source>default-title</source>
+        <target>predvoleny-titulok</target>
+      </segment>
+    </unit>
+    <unit id="ORnQHm." name="Shortlink">
+      <segment>
+        <source>Shortlink</source>
+        <target>Skrátený odkaz</target>
+      </segment>
+    </unit>
+    <unit id="GgpqNso" name="alias">
+      <segment>
+        <source>alias</source>
+        <target>alias</target>
+      </segment>
+    </unit>
+    <unit id="..3kd27" name="Canonical Link">
+      <segment>
+        <source>Canonical Link</source>
+        <target>Kanonický odkaz</target>
+      </segment>
+    </unit>
+    <unit id="V.BIy_i" name="Use this to create an alias or shortlink to this record. Be sure to make it an absolute link">
+      <segment>
+        <source>Use this to create an alias or shortlink to this record. Be sure to make it an absolute link</source>
+        <target>Použite na vytvorenie aliasu alebo skráteného odkazu na tento záznam. Uistite sa, že ide o absolútny odkaz</target>
+      </segment>
+    </unit>
+    <unit id="FwLQ5cl" name="Use with caution, and only if you know what you're doing">
+      <segment>
+        <source>Use with caution, and only if you know what you're doing</source>
+        <target>Používajte s opatrnosťou a iba ak viete, čo robíte</target>
+      </segment>
+    </unit>
+    <unit id="n3BhrCh" name="Meta Robots Tag">
+      <segment>
+        <source>Meta Robots Tag</source>
+        <target>Meta tag Robots</target>
+      </segment>
+    </unit>
+    <unit id="JEVKWPy" name="Open Graph Type">
+      <segment>
+        <source>Open Graph Type</source>
+        <target>Typ Open Graph</target>
+      </segment>
+    </unit>
+    <unit id="johNrI3" name="Leave blank for the default">
+      <segment>
+        <source>Leave blank for the default</source>
+        <target>Ponechajte prázdne pre predvolenú hodnotu</target>
+      </segment>
+    </unit>
+    <unit id="CJ8orGK" name="Will be used as the &lt;tt&gt;&amp;lt;meta name=&quot;description&quot;&amp;gt;&lt;/tt&gt;, and will show up in search engines">
+      <segment>
+        <source>Will be used as the &lt;tt&gt;&amp;lt;meta name="description"&amp;gt;&lt;/tt&gt;, and will show up in search engines</source>
+        <target><![CDATA[Bude použité ako <tt>&lt;meta name="description"&gt;</tt> a zobrazí sa vo vyhľadávačoch]]></target>
+      </segment>
+    </unit>
+    <unit id="0XJxYrt" name="Use this to override the &lt;tt&gt;&amp;lt;link rel=&quot;canonical&quot;&amp;gt;&lt;/tt&gt;">
+      <segment>
+        <source>Use this to override the &lt;tt&gt;&amp;lt;link rel="canonical"&amp;gt;&lt;/tt&gt;</source>
+        <target><![CDATA[Použite na prepísanie <tt>&lt;link rel="canonical"&gt;</tt>]]></target>
+      </segment>
+    </unit>
+    <unit id="tGAPy_h" name="Use this to set the &lt;tt&gt;&amp;lt;meta name=&quot;robots&quot;&amp;gt;&lt;/tt&gt;">
+      <segment>
+        <source>Use this to set the &lt;tt&gt;&amp;lt;meta name="robots"&amp;gt;&lt;/tt&gt;</source>
+        <target><![CDATA[Použite na nastavenie <tt>&lt;meta name="robots"&gt;</tt>]]></target>
+      </segment>
+    </unit>
+    <unit id="AXJdT4M" name="Use this to set the &lt;tt&gt;&amp;lt;meta property=&quot;og:type&quot;&amp;gt;&lt;/tt&gt;">
+      <segment>
+        <source>Use this to set the &lt;tt&gt;&amp;lt;meta property="og:type"&amp;gt;&lt;/tt&gt;</source>
+        <target><![CDATA[Použite na nastavenie <tt>&lt;meta property="og:type"&gt;</tt>]]></target>
+      </segment>
+    </unit>
+    <unit id="z9KeyMt" name="Meta keywords">
+      <segment>
+        <source>Meta keywords</source>
+        <target>Meta kľúčové slová</target>
+      </segment>
+    </unit>
+    <unit id="z9KeyHl" name="Will be used as the &lt;tt&gt;&amp;lt;meta name=&quot;keywords&quot;&amp;gt;&lt;/tt&gt;, and will show up in &lt;em&gt;some&lt;/em&gt; search engines. Use comma separated tags only">
+      <segment>
+        <source>Will be used as the &lt;tt&gt;&amp;lt;meta name="keywords"&amp;gt;&lt;/tt&gt;, and will show up in &lt;em&gt;some&lt;/em&gt; search engines. Use comma separated tags only</source>
+        <target><![CDATA[Bude použité ako <tt>&lt;meta name="keywords"&gt;</tt> a zobrazí sa v <em>niektorých</em> vyhľadávačoch. Používajte iba značky oddelené čiarkami]]></target>
+      </segment>
+    </unit>
+  </file>
+</xliff>

--- a/translations/messages.tr.xlf
+++ b/translations/messages.tr.xlf
@@ -103,10 +103,10 @@
         <target><![CDATA[<tt>&lt;meta name="robots"&gt;</tt> belirlemek için kullanılır]]></target>
       </segment>
     </unit>
-    <unit id="HxdlzS6" name="Use this to set the &lt;tt&gt;&amp;lt;meta name=&quot;og:type&quot;&amp;gt;&lt;/tt&gt;">
+    <unit id="AXJdT4M" name="Use this to set the &lt;tt&gt;&amp;lt;meta property=&quot;og:type&quot;&amp;gt;&lt;/tt&gt;">
       <segment>
-        <source>Use this to set the &lt;tt&gt;&amp;lt;meta name="og:type"&amp;gt;&lt;/tt&gt;</source>
-        <target><![CDATA[<tt>&lt;meta name="og:type"&gt;</tt> belirlemek için kullanılır]]></target>
+        <source>Use this to set the &lt;tt&gt;&amp;lt;meta property="og:type"&amp;gt;&lt;/tt&gt;</source>
+        <target><![CDATA[<tt>&lt;meta property="og:type"&gt;</tt> belirlemek için kullanılır]]></target>
       </segment>
     </unit>
     <unit id="z9KeyMt" name="Meta keywords">

--- a/translations/messages.tr.xlf
+++ b/translations/messages.tr.xlf
@@ -61,10 +61,10 @@
         <target>Canonical bağlantı</target>
       </segment>
     </unit>
-    <unit id="pCpmxa8" name="Use this to create an alias or shortlink to this record. Be sure to make it an absolute link.">
+    <unit id="V.BIy_i" name="Use this to create an alias or shortlink to this record. Be sure to make it an absolute link">
       <segment>
-        <source>Use this to create an alias or shortlink to this record. Be sure to make it an absolute link.</source>
-        <target>Bu kayıt için bir kısa bağlantı veya takma ad oluşturmak için burayı kullanın. Mutlak bir bağlantı yaptığınızdan emin olun.</target>
+        <source>Use this to create an alias or shortlink to this record. Be sure to make it an absolute link</source>
+        <target>Bu kayıt için bir kısa bağlantı veya takma ad oluşturmak için burayı kullanın. Mutlak bir bağlantı yaptığınızdan emin olun</target>
       </segment>
     </unit>
     <unit id="FwLQ5cl" name="Use with caution, and only if you know what you're doing">

--- a/translations/messages.tr.xlf
+++ b/translations/messages.tr.xlf
@@ -76,13 +76,13 @@
     <unit id="n3BhrCh" name="Meta Robots Tag">
       <segment>
         <source>Meta Robots Tag</source>
-        <target>Meta Robots Tag</target>
+        <target>Meta Robots Etiketi</target>
       </segment>
     </unit>
     <unit id="JEVKWPy" name="Open Graph Type">
       <segment>
         <source>Open Graph Type</source>
-        <target>Open Graph Type</target>
+        <target>Open Graph Türü</target>
       </segment>
     </unit>
     <unit id="johNrI3" name="Leave blank for the default">
@@ -94,7 +94,7 @@
     <unit id="CJ8orGK" name="Will be used as the &lt;tt&gt;&amp;lt;meta name=&quot;description&quot;&amp;gt;&lt;/tt&gt;, and will show up in search engines">
       <segment>
         <source>Will be used as the &lt;tt&gt;&amp;lt;meta name="description"&amp;gt;&lt;/tt&gt;, and will show up in search engines</source>
-        <target><![CDATA[<tt>&lt;meta name="description"&gt;</tt> belirlemek için kullanılır, ve arama motorlarında görüntülenecek]]></target>
+        <target><![CDATA[<tt>&lt;meta name="description"&gt;</tt> olarak kullanılacak ve arama motorlarında görüntülenecektir]]></target>
       </segment>
     </unit>
     <unit id="0XJxYrt" name="Use this to override the &lt;tt&gt;&amp;lt;link rel=&quot;canonical&quot;&amp;gt;&lt;/tt&gt;">

--- a/translations/messages.tr.xlf
+++ b/translations/messages.tr.xlf
@@ -70,7 +70,7 @@
     <unit id="FwLQ5cl" name="Use with caution, and only if you know what you're doing">
       <segment>
         <source>Use with caution, and only if you know what you're doing</source>
-        <target>Dikkatli kullanın, ne yaptığınızı biliyorsanız kullanın</target>
+        <target>Dikkatli kullanın ve yalnızca ne yaptığınızı biliyorsanız değiştirin</target>
       </segment>
     </unit>
     <unit id="n3BhrCh" name="Meta Robots Tag">

--- a/translations/messages.tr.xlf
+++ b/translations/messages.tr.xlf
@@ -37,6 +37,12 @@
         <target>Varsayılan başlık</target>
       </segment>
     </unit>
+    <unit id="lONBiUz" name="default-title">
+      <segment>
+        <source>default-title</source>
+        <target>varsayilan-baslik</target>
+      </segment>
+    </unit>
     <unit id="ORnQHm." name="Shortlink">
       <segment>
         <source>Shortlink</source>

--- a/translations/messages.uk.xlf
+++ b/translations/messages.uk.xlf
@@ -52,7 +52,7 @@
     <unit id="GgpqNso" name="alias">
       <segment>
         <source>alias</source>
-        <target>alias</target>
+        <target>псевдонім</target>
       </segment>
     </unit>
     <unit id="..3kd27" name="Canonical Link">

--- a/translations/messages.uk.xlf
+++ b/translations/messages.uk.xlf
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="uk">
+  <file id="messages.uk">
+    <unit id="4TCRcpL" name="SEO Title">
+      <segment>
+        <source>SEO Title</source>
+        <target>SEO Заголовок</target>
+      </segment>
+    </unit>
+    <unit id="3p.vSSI" name="Will be used as the &lt;tt&gt;&amp;lt;title&amp;gt;&lt;/tt&gt; and in search engines">
+      <segment>
+        <source>Will be used as the &lt;tt&gt;&amp;lt;title&amp;gt;&lt;/tt&gt; and in search engines</source>
+        <target><![CDATA[Буде використано як <tt>&lt;title&gt;</tt> та в пошукових системах]]></target>
+      </segment>
+    </unit>
+    <unit id="HdE0ldo" name="Limit the length to %number% characters">
+      <segment>
+        <source>Limit the length to %number% characters</source>
+        <target>Обмежте довжину до %number% символів</target>
+      </segment>
+    </unit>
+    <unit id="JPCo9LS" name="Meta description">
+      <segment>
+        <source>Meta description</source>
+        <target>Мета-опис</target>
+      </segment>
+    </unit>
+    <unit id="2PqBQn1" name="Google snippet preview">
+      <segment>
+        <source>Google snippet preview</source>
+        <target>Попередній перегляд фрагмента Google</target>
+      </segment>
+    </unit>
+    <unit id="L.07lHq" name="Default title">
+      <segment>
+        <source>Default title</source>
+        <target>Заголовок за замовчуванням</target>
+      </segment>
+    </unit>
+    <unit id="lONBiUz" name="default-title">
+      <segment>
+        <source>default-title</source>
+        <target>zagolovok-za-zamovchuvannyam</target>
+      </segment>
+    </unit>
+    <unit id="ORnQHm." name="Shortlink">
+      <segment>
+        <source>Shortlink</source>
+        <target>Коротке посилання</target>
+      </segment>
+    </unit>
+    <unit id="GgpqNso" name="alias">
+      <segment>
+        <source>alias</source>
+        <target>alias</target>
+      </segment>
+    </unit>
+    <unit id="..3kd27" name="Canonical Link">
+      <segment>
+        <source>Canonical Link</source>
+        <target>Канонічне посилання</target>
+      </segment>
+    </unit>
+    <unit id="V.BIy_i" name="Use this to create an alias or shortlink to this record. Be sure to make it an absolute link">
+      <segment>
+        <source>Use this to create an alias or shortlink to this record. Be sure to make it an absolute link</source>
+        <target>Використовуйте це, щоб створити псевдонім або коротке посилання на цей запис. Переконайтеся, що це абсолютне посилання</target>
+      </segment>
+    </unit>
+    <unit id="FwLQ5cl" name="Use with caution, and only if you know what you're doing">
+      <segment>
+        <source>Use with caution, and only if you know what you're doing</source>
+        <target>Використовуйте обережно і лише якщо ви знаєте, що робите</target>
+      </segment>
+    </unit>
+    <unit id="n3BhrCh" name="Meta Robots Tag">
+      <segment>
+        <source>Meta Robots Tag</source>
+        <target>Мета-тег Robots</target>
+      </segment>
+    </unit>
+    <unit id="JEVKWPy" name="Open Graph Type">
+      <segment>
+        <source>Open Graph Type</source>
+        <target>Тип Open Graph</target>
+      </segment>
+    </unit>
+    <unit id="johNrI3" name="Leave blank for the default">
+      <segment>
+        <source>Leave blank for the default</source>
+        <target>Залиште порожнім для значення за замовчуванням</target>
+      </segment>
+    </unit>
+    <unit id="CJ8orGK" name="Will be used as the &lt;tt&gt;&amp;lt;meta name=&quot;description&quot;&amp;gt;&lt;/tt&gt;, and will show up in search engines">
+      <segment>
+        <source>Will be used as the &lt;tt&gt;&amp;lt;meta name="description"&amp;gt;&lt;/tt&gt;, and will show up in search engines</source>
+        <target><![CDATA[Буде використано як <tt>&lt;meta name="description"&gt;</tt> та відображатиметься в пошукових системах]]></target>
+      </segment>
+    </unit>
+    <unit id="0XJxYrt" name="Use this to override the &lt;tt&gt;&amp;lt;link rel=&quot;canonical&quot;&amp;gt;&lt;/tt&gt;">
+      <segment>
+        <source>Use this to override the &lt;tt&gt;&amp;lt;link rel="canonical"&amp;gt;&lt;/tt&gt;</source>
+        <target><![CDATA[Використовуйте це, щоб перевизначити <tt>&lt;link rel="canonical"&gt;</tt>]]></target>
+      </segment>
+    </unit>
+    <unit id="tGAPy_h" name="Use this to set the &lt;tt&gt;&amp;lt;meta name=&quot;robots&quot;&amp;gt;&lt;/tt&gt;">
+      <segment>
+        <source>Use this to set the &lt;tt&gt;&amp;lt;meta name="robots"&amp;gt;&lt;/tt&gt;</source>
+        <target><![CDATA[Використовуйте це, щоб встановити <tt>&lt;meta name="robots"&gt;</tt>]]></target>
+      </segment>
+    </unit>
+    <unit id="AXJdT4M" name="Use this to set the &lt;tt&gt;&amp;lt;meta property=&quot;og:type&quot;&amp;gt;&lt;/tt&gt;">
+      <segment>
+        <source>Use this to set the &lt;tt&gt;&amp;lt;meta property="og:type"&amp;gt;&lt;/tt&gt;</source>
+        <target><![CDATA[Використовуйте це, щоб встановити <tt>&lt;meta property="og:type"&gt;</tt>]]></target>
+      </segment>
+    </unit>
+    <unit id="z9KeyMt" name="Meta keywords">
+      <segment>
+        <source>Meta keywords</source>
+        <target>Мета-ключові слова</target>
+      </segment>
+    </unit>
+    <unit id="z9KeyHl" name="Will be used as the &lt;tt&gt;&amp;lt;meta name=&quot;keywords&quot;&amp;gt;&lt;/tt&gt;, and will show up in &lt;em&gt;some&lt;/em&gt; search engines. Use comma separated tags only">
+      <segment>
+        <source>Will be used as the &lt;tt&gt;&amp;lt;meta name="keywords"&amp;gt;&lt;/tt&gt;, and will show up in &lt;em&gt;some&lt;/em&gt; search engines. Use comma separated tags only</source>
+        <target><![CDATA[Буде використано як <tt>&lt;meta name="keywords"&gt;</tt> та відображатиметься в <em>деяких</em> пошукових системах. Використовуйте лише теги, розділені комами]]></target>
+      </segment>
+    </unit>
+  </file>
+</xliff>


### PR DESCRIPTION
## Summary

This PR expands multi-language support across the `bolt-seo` extension by adding 10 new translation catalogues, refining existing translations, and fixing several template helper text issues.

---

## Key Changes

### 🌐 Internationalization (i18n)

- **Added translation catalogues for 10 new locales:**
  - German (`de`)
  - Spanish (`es`)
  - Hungarian (`hu`)
  - Italian (`it`)
  - Dutch (`nl`)
  - Polish (`pl`)
  - Portuguese (`pt`)
  - Romanian (`ro`)
  - Slovak (`sk`)
  - Ukrainian (`uk`)
- **Improved existing translations:**
  - **French (`fr`)** — corrected helper text wording and translated the previously missing **Meta description** label.
  - **Russian (`ru`)** — removed trailing periods from titles and cleaned up redundant snippet labels.
  - **Turkish (`tr`)** — improved helper text wording and clarified the warning message.
  - **Ukrainian (`uk`)** — localized the term `alias` to `псевдонім`.
  - **Czech (`cs`)** and **English (`en`)** — added the missing `default-title` slug fallback entries.

### 🛠️ SEO field template & helper fixes (`seo.html.twig`)

- **Open Graph helper** — corrected the helper text from `<meta name="og:type">` to `<meta property="og:type">` to match the Open Graph specification and the generated HTML.
- **Shortlink helper** — removed an accidental double period (`..` → `.`) at the end of the helper text.
- **Translation catalogue alignment** — added the missing `default-title` translation used by `SeoExtension::seoFieldValue` when generating fallback slugs.


## Testing

### New `de` translations

<img width="1062" height="1250" alt="Screenshot 2026-07-26 at 10 15 06" src="https://github.com/user-attachments/assets/7b2c36f6-a6c2-44d2-a507-858781ea190b" />

### Existing `fr` translations
<img width="1041" height="1236" alt="Screenshot 2026-07-26 at 10 18 46" src="https://github.com/user-attachments/assets/85135a68-33e5-4577-b338-ead460b5ea75" />

