### PR TITLE
chore: raise PHPStan to level 8 and add PHP 8.5 to CI

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ '8.2', '8.3', '8.4' ]
+        php-version: [ '8.2', '8.3', '8.4', '8.5' ]
         actions:
           - name: Coding Standard
             # tip: add "--ansi" to commands in CI to make them full of colors

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 5
+    level: 6
 
     paths:
         - src

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 7
+    level: 8
 
     paths:
         - src

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 6
+    level: 7
 
     paths:
         - src

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -8,6 +8,7 @@ use Appolo\BoltSeo\Seo\Seo;
 use Appolo\BoltSeo\Widget\SeoInjectorWidget;
 use Bolt\Extension\BaseExtension;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class Extension extends BaseExtension
 {
@@ -23,12 +24,15 @@ class Extension extends BaseExtension
         // Therefore it is only inserted once even if you have multiple fields of this field type
         $this->addWidget(new SeoInjectorWidget());
 
+        /** @var TranslatorInterface $translator */
+        $translator = $this->getContainer()->get('translator');
+
         $seo = new Seo(
             $this->getTwig(),
             $this->getConfig(),
             $this->getBoltConfig(),
             $this->getRequest(),
-            $this->getContainer()->get('translator')
+            $translator
         );
         $this->getTwig()->addGlobal('seo', $seo);
     }
@@ -45,6 +49,10 @@ class Extension extends BaseExtension
         $container = $this->getContainer();
         $projectDir = $container->getParameter('kernel.project_dir');
         $public = $container->getParameter('bolt.public_folder');
+
+        if (! \is_string($projectDir) || ! \is_string($public)) {
+            throw new \RuntimeException('The "kernel.project_dir" and "bolt.public_folder" container parameters must be strings.');
+        }
 
         $source = \dirname(__DIR__) . '/assets/';
         $destination = $projectDir . '/' . $public . '/assets/';

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -7,6 +7,7 @@ namespace Appolo\BoltSeo;
 use Appolo\BoltSeo\Seo\Seo;
 use Appolo\BoltSeo\Widget\SeoInjectorWidget;
 use Bolt\Extension\BaseExtension;
+use RuntimeException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -51,7 +52,7 @@ class Extension extends BaseExtension
         $public = $container->getParameter('bolt.public_folder');
 
         if (! \is_string($projectDir) || ! \is_string($public)) {
-            throw new \RuntimeException('The "kernel.project_dir" and "bolt.public_folder" container parameters must be strings.');
+            throw new RuntimeException('The "kernel.project_dir" and "bolt.public_folder" container parameters must be strings.');
         }
 
         $source = \dirname(__DIR__) . '/assets/';

--- a/src/Field/SeoField.php
+++ b/src/Field/SeoField.php
@@ -19,7 +19,7 @@ class SeoField extends Field implements Excerptable, FieldInterface, RawPersista
     /**
      * Override getTwigValue to render field as html
      */
-    public function getTwigValue()
+    public function getTwigValue(): Markup
     {
         $value = $this->getParsedValue();
 

--- a/src/Seo/ContentField.php
+++ b/src/Seo/ContentField.php
@@ -10,6 +10,9 @@ use Bolt\Entity\Field;
 
 class ContentField
 {
+    /**
+     * @param array<int, string> $fields
+     */
     public static function getFieldDefinition(Content $content, array $fields = []): ?ContentType
     {
         $definitionFields = $content->getDefinition()->get('fields');
@@ -22,6 +25,9 @@ class ContentField
         return null;
     }
 
+    /**
+     * @param array<int, string> $fields
+     */
     public static function getField(Content $content, array $fields = []): ?Field
     {
         foreach ($fields as $fieldName) {

--- a/src/Seo/ContentField.php
+++ b/src/Seo/ContentField.php
@@ -15,7 +15,12 @@ class ContentField
      */
     public static function getFieldDefinition(Content $content, array $fields = []): ?ContentType
     {
-        $definitionFields = $content->getDefinition()->get('fields');
+        $definition = $content->getDefinition();
+        if ($definition === null) {
+            return null;
+        }
+
+        $definitionFields = $definition->get('fields');
         foreach ($fields as $fieldName) {
             if ($definitionFields->has($fieldName)) {
                 return $definitionFields->get($fieldName);

--- a/src/Seo/Seo.php
+++ b/src/Seo/Seo.php
@@ -29,9 +29,16 @@ class Seo
     protected ?Content $record = null;
     protected ?ContentType $contentType = null;
     protected ?string $routeType;
+
+    /** @var array<string, mixed>|null */
     protected ?array $defaultsOverride = null;
+
+    /** @var array<string, mixed> */
     protected array $seoData = [];
 
+    /**
+     * @param Collection<string, mixed> $config
+     */
     public function __construct(
         private readonly Environment $twig,
         private readonly Collection $config,
@@ -221,12 +228,12 @@ class Seo
         return $this->trimKeywords($keywords);
     }
 
-    public function ogtype()
+    public function ogtype(): string
     {
         $this->initialize();
 
         if (! empty($this->defaultsOverride['ogtype'])) {
-            return $this->defaultsOverride['ogtype'];
+            return (string) $this->defaultsOverride['ogtype'];
         }
 
         if ($this->seoData && isset($this->seoData['og']) && $this->seoData['og'] !== '') {
@@ -240,12 +247,12 @@ class Seo
         return 'website';
     }
 
-    public function robots()
+    public function robots(): string
     {
         $this->initialize();
 
         if (! empty($this->defaultsOverride['robots'])) {
-            return $this->defaultsOverride['robots'];
+            return (string) $this->defaultsOverride['robots'];
         }
 
         if ($this->seoData && isset($this->seoData['robots']) && $this->seoData['robots'] !== '') {

--- a/src/Twig/SeoExtension.php
+++ b/src/Twig/SeoExtension.php
@@ -121,7 +121,12 @@ class SeoExtension extends AbstractExtension
 
     private function getExtension(): ExtensionInterface
     {
-        return $this->extensionRegistry->getExtension('Appolo\\BoltSeo');
+        $extension = $this->extensionRegistry->getExtension('Appolo\\BoltSeo');
+        if ($extension === null) {
+            throw new \RuntimeException('The "Appolo\\BoltSeo" extension is not registered.');
+        }
+
+        return $extension;
     }
 
     /**

--- a/src/Twig/SeoExtension.php
+++ b/src/Twig/SeoExtension.php
@@ -14,6 +14,7 @@ use Bolt\Extension\ExtensionInterface;
 use Bolt\Extension\ExtensionRegistry;
 use Bolt\Utils\Html;
 use Illuminate\Support\Collection;
+use RuntimeException;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
@@ -123,7 +124,7 @@ class SeoExtension extends AbstractExtension
     {
         $extension = $this->extensionRegistry->getExtension('Appolo\\BoltSeo');
         if ($extension === null) {
-            throw new \RuntimeException('The "Appolo\\BoltSeo" extension is not registered.');
+            throw new RuntimeException('The "Appolo\\BoltSeo" extension is not registered.');
         }
 
         return $extension;

--- a/src/Twig/SeoExtension.php
+++ b/src/Twig/SeoExtension.php
@@ -37,6 +37,9 @@ class SeoExtension extends AbstractExtension
         ];
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function seoGetConfig(): array
     {
         return $this->getExtensionConfig()->toArray();
@@ -121,6 +124,9 @@ class SeoExtension extends AbstractExtension
         return $this->extensionRegistry->getExtension('Appolo\\BoltSeo');
     }
 
+    /**
+     * @return Collection<string, mixed>
+     */
     private function getExtensionConfig(): Collection
     {
         /** @var Extension $extension */

--- a/src/Widget/SeoInjectorWidget.php
+++ b/src/Widget/SeoInjectorWidget.php
@@ -18,6 +18,9 @@ class SeoInjectorWidget extends BaseWidget implements TwigAwareInterface
     protected $template = '@seo/injector.html.twig';
     protected $priority = 200;
 
+    /**
+     * @param array<string, mixed> $params
+     */
     public function run(array $params = []): ?string
     {
         $request = $this->getExtension()->getRequest();


### PR DESCRIPTION
## Summary

Raises static analysis from PHPStan level 5 to level 8 in three incremental steps, fixing every issue surfaced at each level. Also adds PHP 8.5 to the CI matrix.

No behavioural changes are intended. Most changes consist of improved type annotations and null guards on paths that were already unreachable or correct in practice, with two genuine robustness improvements noted below.

## Changes by level

### Level 6 — iterable value types & missing return types

- `ContentField::getFieldDefinition()` and `getField()` — annotated `$fields` as `array<int, string>`.
- `SeoInjectorWidget::run()` — annotated `$params` as `array<string, mixed>`.
- `Seo` — typed `$defaultsOverride` and `$seoData` as `array<string, mixed>`, and the constructor's `$config` as `Collection<string, mixed>`.
- `SeoExtension` — added `@return array<string, mixed>` to `seoGetConfig()` and `Collection<string, mixed>` to `getExtensionConfig()`.
- `SeoField::getTwigValue()` — declared a `: Markup` return type. The parent method's untyped `@return string|array|Markup|bool` annotation was the source of the unspecified array-type warning.
- `Seo::ogtype()` and `robots()` — declared `: string`, casting the configuration-override branch, which was the only path not already guaranteed to return a string.

### Level 7 — unresolved union types

- `Extension::initialize()` — `getContainer()->get('translator')` returns `object`; narrowed it to `TranslatorInterface` via an inline annotation, matching the existing pattern used in `SeoExtension`.
- `Extension::install()` — `getParameter()` returns `array|bool|float|int|string|UnitEnum|null`. A simple `(string)` cast is insufficient because arrays are not safely castable. The code now validates with `is_string()` and throws otherwise.

  This is a genuine robustness improvement: a non-string `bolt.public_folder` value would previously have caused `Filesystem::mirror()` to copy assets into an invalid path.

### Level 8 — member access on nullable values

- `ContentField::getFieldDefinition()` — `Content::getDefinition()` returns `?ContentType`; added an early return before dereferencing `->get('fields')`.
- `Seo::cleanUp()` — `preg_replace()` returns `string|null` (`null` on failure, such as malformed UTF-8 with the `/u` modifier), while the method declares `string`. The method now falls back to the original input instead of propagating `null`.

  This is a genuine robustness improvement rather than a PHPStan-only change.

- `SeoExtension::getExtension()` — `ExtensionRegistry::getExtension()` returns `?ExtensionInterface`; now throws if the extension is not registered instead of returning `null` from a non-nullable method.

## CI

Added PHP **8.5** to the `code_analysis` matrix after verifying compatibility:

- `composer check-platform-reqs` passes on PHP 8.5 (exit code `0`).
- `composer why-not php 8.5` reports no dependencies with an upper PHP version constraint below 8.5.

The `rector_analysis` job remains pinned to PHP 8.4 because it is a single, non-matrix job and Rector's output is version-independent for this project.

## Testing

- Extension works as expected

<img width="1494" height="1285" alt="image" src="https://github.com/user-attachments/assets/64c47474-b2b6-4be9-9d7d-4cafc2020138" />

