### PR TITLE
feat: migrate CSS units from px/em to rem in seo.css

### DIFF
--- a/assets/seo/seo.css
+++ b/assets/seo/seo.css
@@ -1,14 +1,14 @@
 .seo_snippet {
     background-color: #fff;
-    padding: 12px;
-    font-family: "Helvetica Neue",Arial,sans-serif;
+    padding: 0.75rem;
+    font-family: "Helvetica Neue", Arial, sans-serif;
 }
 
 .seo_snippet .url {
     color: #3C4043;
-    font-size: 14px;
+    font-size: 0.875rem;
     line-height: 1.54;
-    margin-bottom: 3px;
+    margin-bottom: 0.1875rem;
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;
@@ -18,27 +18,27 @@
     display: inline-block;
     width: 0;
     height: 0;
-    margin-left: 2px;
+    margin-left: 0.125rem;
     vertical-align: middle;
-    border-top: 4px dashed;
-    border-right: 4px solid transparent;
-    border-left: 4px solid transparent;
+    border-top: 0.25rem dashed;
+    border-right: 0.25rem solid transparent;
+    border-left: 0.25rem solid transparent;
 }
 
 .seo_snippet .title {
     color: #1a0dab;
-    font-size: 20px;
+    font-size: 1.25rem;
     line-height: 1.3;
     overflow: hidden;
-    padding-right: 16.5px;
-    height: 1.3em;
-    padding-top: 0px;
-    margin-bottom: 3px;
+    padding-right: 1.03125rem;
+    height: 1.625rem;
+    padding-top: 0;
+    margin-bottom: 0.1875rem;
     cursor: pointer;
 }
 
 .seo_snippet .description {
     color: #3C4043;
-    font-size: 14px;
+    font-size: 0.875rem;
     line-height: 1.57;
 }


### PR DESCRIPTION
## Summary

Migrates all `px` and `em` units in `seo.css` to `rem` for improved scalability and accessibility. All rendered dimensions remain identical under the default `16px` root font size.

## Conversion table

| Property | Original | Converted |
|----------|----------|-----------|
| `padding` | `12px` | `0.75rem` |
| `font-size` | `14px` | `0.875rem` |
| `font-size` | `20px` | `1.25rem` |
| `margin-bottom` | `3px` | `0.1875rem` |
| `margin-left` | `2px` | `0.125rem` |
| `border-*` | `4px` | `0.25rem` |
| `padding-right` | `16.5px` | `1.03125rem` |
| `padding-top` | `0px` | `0` |
| `height` | `1.3em` | `1.625rem` |

## Why

- **Accessibility** — `rem` units respect the user's preferred browser font size, improving support for users who increase their default text size.
- **Consistency** — all sizing now uses a single relative unit (`rem`), making the stylesheet easier to maintain and reason about.
- **No visual change** — this is a pure refactor; rendered dimensions remain unchanged with the default `16px` root font size.

## Testing

<img width="2316" height="1274" alt="Screenshot 2026-07-26 at 10 35 06" src="https://github.com/user-attachments/assets/01b9236b-8d46-4b36-afe9-8b9c7b1cb34f" />

