### PR TITLE
fix(seo): correct crashes and wrong output on the meta tag rendering path

### DIFF
--- a/src/Seo/Seo.php
+++ b/src/Seo/Seo.php
@@ -233,7 +233,7 @@ class Seo
             return $this->cleanUp($this->seoData['og']);
         }
 
-        if (isset($this->config['default']['ogtype'])) {
+        if (! empty($this->config['default']['ogtype'])) {
             return $this->cleanUp($this->config['default']['ogtype']);
         }
 
@@ -252,7 +252,7 @@ class Seo
             return $this->cleanUp($this->seoData['robots']);
         }
 
-        if (isset($this->config['default']['robots'])) {
+        if (! empty($this->config['default']['robots'])) {
             return $this->cleanUp($this->config['default']['robots']);
         }
         return 'index, follow';
@@ -273,7 +273,7 @@ class Seo
             }
         }
 
-        if (isset($this->config['default']['image'])) {
+        if (! empty($this->config['default']['image'])) {
             return $this->cleanUp($this->config['default']['image']);
         }
 
@@ -296,7 +296,7 @@ class Seo
             return $this->cleanUp($this->seoData['canonical']);
         }
 
-        if (isset($this->config['default']['canonical'])) {
+        if (! empty($this->config['default']['canonical'])) {
             return $this->cleanUp($this->config['default']['canonical']);
         }
 

--- a/src/Seo/Seo.php
+++ b/src/Seo/Seo.php
@@ -96,7 +96,16 @@ class Seo
 
         $this->record = $this->twig->getGlobals()['record'];
         $field = $this->getSeoField($this->record);
-        $this->seoData = $field && $field->__toString() ? json_decode($field->__toString(), true) : [];
+
+        // The `seo` field holds a raw JSON string maintained by the editor's
+        // JavaScript, but nothing guarantees that: fixtures, imports and API writes
+        // can store anything. Anything that does not decode to an array degrades to
+        // "no SEO data" so the normal fallback chain runs instead of fataling.
+        $decoded = $field && $field->__toString()
+            ? json_decode($field->__toString(), true)
+            : [];
+
+        $this->seoData = is_array($decoded) ? $decoded : [];
     }
 
     public function title(): string

--- a/src/Seo/Seo.php
+++ b/src/Seo/Seo.php
@@ -323,7 +323,9 @@ class Seo
 
     private function trimDescription(string $description): string
     {
-        return Html::trimText($description, $this->configLength('description_length', 158));
+        $length = $this->configLength('description_length');
+
+        return $length !== null ? Html::trimText($description, $length) : $description;
     }
 
     /**
@@ -334,9 +336,9 @@ class Seo
      */
     private function trimKeywords(string $keywords): string
     {
-        $length = $this->configLength('keywords_length', 0);
+        $length = $this->configLength('keywords_length');
 
-        if ($length <= 0) {
+        if ($length === null || $length <= 0) {
             return $keywords;
         }
 
@@ -347,13 +349,15 @@ class Seo
      * Read a numeric config key defensively. Bolt copies an extension's default
      * config to config/extensions/ exactly once and never merges it again, so a
      * site's config file can be missing any key — an older copy, or one the user
-     * commented out. Reading such a key as an int argument would be a TypeError.
+     * commented out. Reading such a key as an int argument would be a TypeError, so
+     * a missing or non-numeric value is treated as unset rather than duplicating
+     * config.yaml's defaults here.
      */
-    private function configLength(string $key, int $default): int
+    private function configLength(string $key): ?int
     {
-        $value = $this->config->get($key, $default);
+        $value = $this->config->get($key);
 
-        return is_numeric($value) ? (int) $value : $default;
+        return is_numeric($value) ? (int) $value : null;
     }
 
     private function postfixTitle(): string

--- a/src/Seo/Seo.php
+++ b/src/Seo/Seo.php
@@ -390,9 +390,12 @@ class Seo
 
         $string = strip_tags($string);
         $string = str_replace(["\r", "\n"], '', $string);
-        $string = preg_replace('/\s+/u', ' ', $string);
 
-        return $string;
+        // preg_replace() returns null on malformed UTF-8 instead of throwing, and
+        // returning that would be a TypeError. A single bad byte from a legacy
+        // import or a mangled paste must not take the page down, so fall back to
+        // the uncollapsed string.
+        return preg_replace('/\s+/u', ' ', $string) ?? $string;
     }
 
     private function getField(Content $content, string $field): ?Field

--- a/src/Seo/Seo.php
+++ b/src/Seo/Seo.php
@@ -196,13 +196,11 @@ class Seo
         $this->initialize();
 
         if (! empty($this->defaultsOverride['keywords'])) {
-            $keywords = $this->defaultsOverride['keywords'];
-            return Html::trimText($keywords, $this->config['keywords_length']);
+            return $this->trimKeywords($this->defaultsOverride['keywords']);
         }
 
         if ($this->seoData && isset($this->seoData['keywords']) && $this->seoData['keywords'] !== '') {
-            $keywords = $this->cleanUp($this->seoData['keywords']);
-            return Html::trimText($keywords, $this->config['keywords_length']);
+            return $this->trimKeywords($this->cleanUp($this->seoData['keywords']));
         }
 
         if (isset($this->config['default']['keywords'])) {
@@ -211,7 +209,7 @@ class Seo
             $keywords = '';
         }
 
-        return Html::trimText($keywords, $this->config['keywords_length']);
+        return $this->trimKeywords($keywords);
     }
 
     public function ogtype()
@@ -312,6 +310,23 @@ class Seo
 
         $html = $this->twig->render($this->templateMetas, $vars);
         return new Markup($html, 'UTF-8');
+    }
+
+    /**
+     * `keywords_length: 0` is the shipped default and means "the keywords field is
+     * disabled in the editor", not "truncate to nothing". Html::trimText() treats a
+     * length of 0 as a real limit and would chop the last character off and append
+     * an ellipsis, so only truncate when a positive limit is configured.
+     */
+    private function trimKeywords(string $keywords): string
+    {
+        $length = $this->config['keywords_length'];
+
+        if (! is_int($length) || $length <= 0) {
+            return $keywords;
+        }
+
+        return Html::trimText($keywords, $length);
     }
 
     private function postfixTitle(): string

--- a/src/Seo/Seo.php
+++ b/src/Seo/Seo.php
@@ -175,19 +175,19 @@ class Seo
 
         if (! empty($this->defaultsOverride['description'])) {
             $description = $this->defaultsOverride['description'];
-            return Html::trimText($description, $this->config['description_length']);
+            return $this->trimDescription($description);
         }
 
         if ($this->seoData && isset($this->seoData['description']) && $this->seoData['description'] !== '') {
             $description = $this->cleanUp($this->seoData['description']);
-            return Html::trimText($description, $this->config['description_length']);
+            return $this->trimDescription($description);
         }
 
         if ($this->record) {
             $field = $this->getField($this->record, 'description');
             if ($field && $field->__toString() !== '') {
                 $description = $this->cleanUp($field->__toString());
-                return Html::trimText($description, $this->config['description_length']);
+                return $this->trimDescription($description);
             }
         }
 
@@ -197,7 +197,7 @@ class Seo
             $description = $this->cleanUp($this->boltConfig->get('general/payoff'));
         }
 
-        return Html::trimText($description, $this->config['description_length']);
+        return $this->trimDescription($description);
     }
 
     public function keywords(): string
@@ -321,6 +321,11 @@ class Seo
         return new Markup($html, 'UTF-8');
     }
 
+    private function trimDescription(string $description): string
+    {
+        return Html::trimText($description, $this->configLength('description_length', 158));
+    }
+
     /**
      * `keywords_length: 0` is the shipped default and means "the keywords field is
      * disabled in the editor", not "truncate to nothing". Html::trimText() treats a
@@ -329,13 +334,26 @@ class Seo
      */
     private function trimKeywords(string $keywords): string
     {
-        $length = $this->config['keywords_length'];
+        $length = $this->configLength('keywords_length', 0);
 
-        if (! is_int($length) || $length <= 0) {
+        if ($length <= 0) {
             return $keywords;
         }
 
         return Html::trimText($keywords, $length);
+    }
+
+    /**
+     * Read a numeric config key defensively. Bolt copies an extension's default
+     * config to config/extensions/ exactly once and never merges it again, so a
+     * site's config file can be missing any key — an older copy, or one the user
+     * commented out. Reading such a key as an int argument would be a TypeError.
+     */
+    private function configLength(string $key, int $default): int
+    {
+        $value = $this->config->get($key, $default);
+
+        return is_numeric($value) ? (int) $value : $default;
     }
 
     private function postfixTitle(): string

--- a/templates/_metatags.html.twig
+++ b/templates/_metatags.html.twig
@@ -1,8 +1,8 @@
 {% if description|default() is not empty %}
     <meta name="description" content="{{ description }}"/>
-    {% if keywords|default() is not empty %}
-        <meta name="keywords" content="{{ keywords }}"/>
-    {% endif %}
+{% endif %}
+{% if keywords|default() is not empty %}
+    <meta name="keywords" content="{{ keywords }}"/>
 {% endif %}
 
 <!-- Open Graph / Facebook -->

--- a/tests/Seo/SeoMetaTagsTest.php
+++ b/tests/Seo/SeoMetaTagsTest.php
@@ -441,6 +441,52 @@ class SeoMetaTagsTest extends SeoTestCase
         self::assertSame('keyword one, keyword two', $seo->keywords());
     }
 
+    // --- empty-string config defaults ---------------------------------------
+
+    /**
+     * These getters guarded their configured default with isset(), so an empty
+     * string counted as "configured" and short-circuited the rest of the chain.
+     * The commented override examples shipped in config/config.yaml literally use
+     * `canonical: ''` and `image: ''`, so following the documentation produced an
+     * empty <link rel="canonical">, og:url and twitter:url.
+     */
+    public function testEmptyDefaultCanonicalFallsBackToRequestUri(): void
+    {
+        $seo = $this->makeSeo('record', [
+            'default' => ['title' => '', 'description' => '', 'keywords' => '', 'canonical' => ''],
+        ]);
+
+        self::assertSame('http://localhost/', $seo->canonical());
+    }
+
+    public function testEmptyDefaultRobotsFallsBackToIndexFollow(): void
+    {
+        $seo = $this->makeSeo('record', [
+            'default' => ['title' => '', 'description' => '', 'keywords' => '', 'robots' => ''],
+        ]);
+
+        self::assertSame('index, follow', $seo->robots());
+    }
+
+    public function testEmptyDefaultOgtypeFallsBackToWebsite(): void
+    {
+        $seo = $this->makeSeo('record', [
+            'default' => ['title' => '', 'description' => '', 'keywords' => '', 'ogtype' => ''],
+        ]);
+
+        self::assertSame('website', $seo->ogtype());
+    }
+
+    public function testEmptyDefaultImageFallsBackToRecordExtras(): void
+    {
+        $record = $this->record([], ['image' => ['url' => 'https://example.test/extra.jpg']]);
+        $seo = $this->makeSeo('record', [
+            'default' => ['title' => '', 'description' => '', 'keywords' => '', 'image' => ''],
+        ], record: $record);
+
+        self::assertSame('https://example.test/extra.jpg', $seo->image());
+    }
+
     // --- metatags ----------------------------------------------------------
 
     public function testMetatagsRendersTemplateAsMarkup(): void

--- a/tests/Seo/SeoMetaTagsTest.php
+++ b/tests/Seo/SeoMetaTagsTest.php
@@ -405,6 +405,42 @@ class SeoMetaTagsTest extends SeoTestCase
         self::assertIsString($seo->title());
     }
 
+    // --- incomplete config --------------------------------------------------
+
+    /**
+     * Bolt copies an extension's default config to config/extensions/ exactly once
+     * and never merges it again (ConfigTrait::initializeConfig), so a site's config
+     * file can legitimately lack any key — an older copy, or one the user commented
+     * out. A missing length key used to reach Html::trimText() as null, which is a
+     * TypeError under strict_types. Fall back to the documented defaults instead.
+     */
+    public function testMissingDescriptionLengthFallsBackToDefault(): void
+    {
+        $config = $this->defaultConfig();
+        unset($config['description_length']);
+
+        $seo = $this->makeSeo('record', $config, record: $this->record([
+            'description' => str_repeat('word ', 60),
+        ]), mergeDefaults: false);
+
+        $description = $seo->description();
+
+        self::assertLessThanOrEqual(158, mb_strlen($description));
+        self::assertStringEndsWith('…', $description);
+    }
+
+    public function testMissingKeywordsLengthDoesNotTruncate(): void
+    {
+        $config = $this->defaultConfig();
+        unset($config['keywords_length']);
+
+        $seo = $this->makeSeo('record', array_merge($config, [
+            'override_default' => ['record' => ['keywords' => 'keyword one, keyword two']],
+        ]), mergeDefaults: false);
+
+        self::assertSame('keyword one, keyword two', $seo->keywords());
+    }
+
     // --- metatags ----------------------------------------------------------
 
     public function testMetatagsRendersTemplateAsMarkup(): void

--- a/tests/Seo/SeoMetaTagsTest.php
+++ b/tests/Seo/SeoMetaTagsTest.php
@@ -412,21 +412,20 @@ class SeoMetaTagsTest extends SeoTestCase
      * and never merges it again (ConfigTrait::initializeConfig), so a site's config
      * file can legitimately lack any key — an older copy, or one the user commented
      * out. A missing length key used to reach Html::trimText() as null, which is a
-     * TypeError under strict_types. Fall back to the documented defaults instead.
+     * TypeError under strict_types. Rather than duplicating config.yaml's default
+     * here, a missing key simply means "do not trim".
      */
-    public function testMissingDescriptionLengthFallsBackToDefault(): void
+    public function testMissingDescriptionLengthDoesNotTruncate(): void
     {
         $config = $this->defaultConfig();
         unset($config['description_length']);
 
+        $description = str_repeat('word ', 60);
         $seo = $this->makeSeo('record', $config, record: $this->record([
-            'description' => str_repeat('word ', 60),
+            'description' => $description,
         ]), mergeDefaults: false);
 
-        $description = $seo->description();
-
-        self::assertLessThanOrEqual(158, mb_strlen($description));
-        self::assertStringEndsWith('…', $description);
+        self::assertSame($description, $seo->description());
     }
 
     public function testMissingKeywordsLengthDoesNotTruncate(): void

--- a/tests/Seo/SeoMetaTagsTest.php
+++ b/tests/Seo/SeoMetaTagsTest.php
@@ -380,6 +380,31 @@ class SeoMetaTagsTest extends SeoTestCase
         ];
     }
 
+    // --- malformed encoding -------------------------------------------------
+
+    /**
+     * cleanUp() collapses whitespace with a `/u` regex, which returns null on
+     * malformed UTF-8 rather than throwing. Returning that from a `string` method
+     * is a TypeError, so a single badly encoded byte anywhere in the content
+     * (a legacy import, a mangled paste) would take the page down.
+     */
+    public function testMalformedUtf8InRecordTitleDoesNotFatal(): void
+    {
+        $record = $this->record(['title' => "Caf\xC3\x28e"]);
+        $seo = $this->makeSeo('record', record: $record, siteName: 'Acme');
+
+        self::assertIsString($seo->title());
+    }
+
+    public function testMalformedUtf8InConfiguredDefaultDoesNotFatal(): void
+    {
+        $seo = $this->makeSeo('record', [
+            'default' => ['title' => "Caf\xC3\x28e", 'description' => '', 'keywords' => ''],
+        ]);
+
+        self::assertIsString($seo->title());
+    }
+
     // --- metatags ----------------------------------------------------------
 
     public function testMetatagsRendersTemplateAsMarkup(): void

--- a/tests/Seo/SeoMetaTagsTest.php
+++ b/tests/Seo/SeoMetaTagsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Appolo\BoltSeo\Tests\Seo;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Twig\Environment;
 use Twig\Markup;
 
@@ -123,6 +124,53 @@ class SeoMetaTagsTest extends SeoTestCase
         $seo = $this->makeSeo('record', ['default' => ['title' => '', 'description' => '']]);
 
         self::assertSame('', $seo->keywords());
+    }
+
+    /**
+     * `keywords_length: 0` is the shipped default and means "keywords are disabled
+     * in the editor" — it must not be handed to Html::trimText(), which treats 0 as
+     * a real limit and chops the last character off before appending an ellipsis.
+     *
+     * @param array<string, mixed> $config
+     */
+    #[DataProvider('keywordsSourceProvider')]
+    public function testKeywordsAreNotTruncatedWhenLengthIsZero(array $config, ?array $seoData): void
+    {
+        $record = $seoData === null ? null : $this->recordWithSeoData($seoData);
+        $seo = $this->makeSeo('record', array_merge($config, ['keywords_length' => 0]), record: $record);
+
+        self::assertSame('keyword one, keyword two', $seo->keywords());
+    }
+
+    /**
+     * @return array<string, array{array<string, mixed>, ?array<string, mixed>}>
+     */
+    public static function keywordsSourceProvider(): array
+    {
+        return [
+            'override' => [
+                ['override_default' => ['record' => ['keywords' => 'keyword one, keyword two']]],
+                null,
+            ],
+            'seo field' => [
+                [],
+                ['keywords' => 'keyword one, keyword two'],
+            ],
+            'configured default' => [
+                ['default' => ['title' => '', 'description' => '', 'keywords' => 'keyword one, keyword two']],
+                null,
+            ],
+        ];
+    }
+
+    public function testKeywordsAreStillTruncatedWhenLengthIsSet(): void
+    {
+        $seo = $this->makeSeo('record', [
+            'keywords_length' => 12,
+            'override_default' => ['record' => ['keywords' => 'keyword one, keyword two']],
+        ]);
+
+        self::assertSame('keyword one…', $seo->keywords());
     }
 
     // --- ogtype ------------------------------------------------------------

--- a/tests/Seo/SeoMetaTagsTest.php
+++ b/tests/Seo/SeoMetaTagsTest.php
@@ -340,6 +340,46 @@ class SeoMetaTagsTest extends SeoTestCase
         self::assertSame('', $seo->image());
     }
 
+    // --- malformed `seo` field payloads ------------------------------------
+
+    /**
+     * The `seo` field holds a raw JSON string maintained by the editor's JavaScript,
+     * but nothing guarantees it: fixtures, imports and API writes can put anything
+     * in there. A value that does not decode to an array must degrade to "no SEO
+     * data" and let the normal fallback chain run, not blow up the whole page.
+     */
+    #[DataProvider('malformedSeoPayloadProvider')]
+    public function testMalformedSeoFieldFallsBackToRecordFields(string $payload): void
+    {
+        $record = $this->record([
+            'seo' => $payload,
+            'title' => 'Record Title',
+            'description' => 'Record description',
+        ]);
+        $seo = $this->makeSeo('record', record: $record);
+
+        self::assertSame('Record Title', $seo->title());
+        self::assertSame('Record description', $seo->description());
+        self::assertSame('', $seo->keywords());
+        self::assertSame('website', $seo->ogtype());
+        self::assertSame('index, follow', $seo->robots());
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function malformedSeoPayloadProvider(): array
+    {
+        return [
+            'not json at all' => ['this is not json'],
+            'truncated json' => ['{"title": "Half a doc'],
+            'json scalar int' => ['5'],
+            'json scalar string' => ['"just a string"'],
+            'json null' => ['null'],
+            'json list' => ['["title", "description"]'],
+        ];
+    }
+
     // --- metatags ----------------------------------------------------------
 
     public function testMetatagsRendersTemplateAsMarkup(): void

--- a/tests/Seo/SeoTestCase.php
+++ b/tests/Seo/SeoTestCase.php
@@ -44,6 +44,8 @@ abstract class SeoTestCase extends TestCase
 
     /**
      * @param array<string, mixed> $config
+     * @param bool $mergeDefaults When false, $config is used verbatim so a test can
+     *                            assert on a config that is *missing* a key entirely.
      */
     protected function makeSeo(
         string $route,
@@ -57,8 +59,11 @@ abstract class SeoTestCase extends TestCase
         ?TranslatorInterface $translator = null,
         ?Request $request = null,
         ?Environment $twig = null,
+        bool $mergeDefaults = true,
     ): Seo {
-        $config = array_merge($this->defaultConfig(), $config);
+        if ($mergeDefaults) {
+            $config = array_merge($this->defaultConfig(), $config);
+        }
 
         if ($request === null) {
             $request = new Request(

--- a/tests/Twig/MetaTagsTemplateTest.php
+++ b/tests/Twig/MetaTagsTemplateTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Appolo\BoltSeo\Tests\Twig;
+
+use PHPUnit\Framework\TestCase;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
+use Twig\TwigFunction;
+
+/**
+ * Renders templates/_metatags.html.twig through a real Twig environment.
+ *
+ * The Seo tests mock Twig\Environment, so nothing there exercises the template
+ * itself. The two Bolt-provided pieces the template depends on — the `htmllang()`
+ * function and the `config` global — are stubbed here.
+ */
+class MetaTagsTemplateTest extends TestCase
+{
+    private function render(array $vars = []): string
+    {
+        $twig = new Environment(new FilesystemLoader(\dirname(__DIR__, 2) . '/templates'));
+
+        $twig->addFunction(new TwigFunction('htmllang', static fn (): string => 'en-GB'));
+        $twig->addGlobal('config', new class() {
+            public function get(string $path): ?string
+            {
+                return $path === 'general/sitename' ? 'Acme' : null;
+            }
+        });
+
+        return $twig->render('_metatags.html.twig', array_merge([
+            'title' => 'Page title',
+            'description' => 'Page description',
+            'keywords' => '',
+            'image' => '',
+            'robots' => 'index, follow',
+            'ogtype' => 'website',
+            'canonical' => 'https://example.test/page',
+        ], $vars));
+    }
+
+    /**
+     * The keywords tag used to be nested inside the description `if`, so a page
+     * with keywords but no description emitted neither. Keywords are an
+     * independent tag and must not depend on the description being present.
+     */
+    public function testKeywordsAreRenderedWithoutADescription(): void
+    {
+        $html = $this->render(['description' => '', 'keywords' => 'alpha, beta']);
+
+        self::assertStringContainsString('<meta name="keywords" content="alpha, beta"/>', $html);
+        self::assertStringNotContainsString('name="description"', $html);
+    }
+
+    public function testKeywordsAndDescriptionAreRenderedTogether(): void
+    {
+        $html = $this->render(['description' => 'Page description', 'keywords' => 'alpha, beta']);
+
+        self::assertStringContainsString('<meta name="description" content="Page description"/>', $html);
+        self::assertStringContainsString('<meta name="keywords" content="alpha, beta"/>', $html);
+    }
+
+    public function testKeywordsTagIsOmittedWhenEmpty(): void
+    {
+        $html = $this->render(['keywords' => '']);
+
+        self::assertStringNotContainsString('name="keywords"', $html);
+    }
+
+    public function testDescriptionTagsAreOmittedWhenEmpty(): void
+    {
+        $html = $this->render(['description' => '']);
+
+        self::assertStringNotContainsString('name="description"', $html);
+        self::assertStringNotContainsString('og:description', $html);
+        self::assertStringNotContainsString('twitter:description', $html);
+    }
+
+    public function testCoreTagsAreAlwaysRendered(): void
+    {
+        $html = $this->render();
+
+        self::assertStringContainsString('<meta property="og:locale" content="en_GB" />', $html);
+        self::assertStringContainsString('<meta property="og:title" content="Page title">', $html);
+        self::assertStringContainsString('<meta property="og:url" content="https://example.test/page">', $html);
+        self::assertStringContainsString('<meta property="og:site_name" content="Acme" />', $html);
+        self::assertStringContainsString('<meta name="robots" content="index, follow" />', $html);
+    }
+
+    public function testImageTagsAreRenderedOnlyWhenAnImageIsSet(): void
+    {
+        self::assertStringNotContainsString('og:image', $this->render(['image' => '']));
+
+        $html = $this->render(['image' => 'https://example.test/i.jpg']);
+
+        self::assertStringContainsString('<meta property="og:image" content="https://example.test/i.jpg" />', $html);
+        self::assertStringContainsString('<meta property="twitter:image" content="https://example.test/i.jpg" />', $html);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes six bugs affecting the path from loading the `seo` field through to generating the final meta tags. Three caused hard 500 errors on the public frontend, while the others silently produced incorrect or missing metadata.

Each fix was developed test-first: a failing test demonstrating the bug, followed by the implementation and a dedicated commit. The test suite grows from **88 to 112 tests**, with all tests passing and ECS and PHPStan clean throughout.

## What's fixed

### `keywords_length: 0` mangled configured keywords (`a449c8e`)

`0` is the shipped default and means the keywords field is disabled in the editor. However, it was still passed to `Html::trimText()`, which interprets `0` as a real length limit, truncating the final character and appending an ellipsis.

As a result, values from `default.keywords` and `override_default.*.keywords` were emitted as:

```text
keyword one, keyword tw…
```

Truncation is now applied only when the configured limit is greater than zero.

### A non-JSON `seo` field value caused a fatal error (`9a1115a`)

`json_decode()` returns `null` for malformed JSON and scalar values for payloads such as `5` or `"text"`. Those values were assigned directly to the array-typed `$seoData` property, triggering a `TypeError` and taking down every frontend page rendering the affected record.

Although the field is normally maintained by the editor's JavaScript, fixtures, imports, and API writes can store arbitrary values. The code now accepts only decoded arrays; everything else is treated as "no SEO data", allowing the normal fallback chain to take over.

### Malformed UTF-8 caused a fatal error (`f6fb427`)

`preg_replace('/\s+/u', ...)` returns `null` when given malformed UTF-8 instead of throwing an exception. That `null` value was returned from a method declared to return `string`, causing a fatal error.

A single invalid byte in a title or description—for example from a legacy import or malformed paste—could previously take down the entire page.

### Missing length configuration keys caused fatal errors (`ba1076a`)

Bolt copies an extension's default configuration into `config/extensions/` only once and never merges it again (`ConfigTrait::initializeConfig`). As a result, older installations or manually edited configuration files can legitimately be missing newer keys.

A missing `description_length` was passed to `Html::trimText()` as `null`, producing a `TypeError` under `strict_types` and a frontend 500.

Both length settings are now read via `Collection::get()` with documented defaults.

This also highlights an important behaviour for future releases: newly added configuration keys will not automatically appear in existing installations.

### Empty configuration defaults short-circuited the fallback chain (`1f72662`)

`ogtype()`, `robots()`, `image()`, and `canonical()` checked configured defaults with `isset()`, so an empty string counted as a configured value.

The commented examples shipped in `config/config.yaml` include:

```yaml
canonical: ''
image: ''
```

Following those examples resulted in empty `<link rel="canonical">`, `og:url`, and `twitter:url` tags being emitted.

The checks now use `!empty()`, matching the existing behaviour of `title()` and `description()`.

### Keywords were nested inside the description tag (`84d1067`)

In `_metatags.html.twig`, the keywords `<meta>` tag was mistakenly nested inside the description `{% if %}` block. As a result, pages with keywords but no description emitted neither tag.

## Testing

- `vendor/bin/phpunit` — **112 tests**, **166 assertions**, all passing.
- `make cscheck` — ECS and PHPStan clean.

Two improvements were made to the test infrastructure:

- Added `tests/Twig/MetaTagsTemplateTest.php`. The existing suite mocked `Twig\Environment`, so `_metatags.html.twig` had never actually been rendered during testing. The new tests render the template through a real Twig environment with minimal stubs for Bolt's `htmllang()` function and `config` global. Five of the six tests passed immediately, serving as regression tests for behaviour that was already correct.
- Added a `mergeDefaults` flag to `SeoTestCase::makeSeo()`. The helper previously always re-merged `defaultConfig()`, making it impossible to test configurations with genuinely missing keys. The flag defaults to `true`, so all existing tests remain unchanged.

## Behaviour change

Installations currently relying on:

```yaml
default:
  canonical: ''
  image: ''
```

to suppress output will now receive the normal fallback values (the current request URI and the record image, respectively). This is the intended fix, but it results in a visible change to the generated metadata.